### PR TITLE
Extend remove-background example in docs

### DIFF
--- a/docs/source/getting_started/remove_background/index.rst
+++ b/docs/source/getting_started/remove_background/index.rst
@@ -6,6 +6,9 @@ remove-background
 In this tutorial, we will run ``remove-background`` on a small dataset derived from the 10x Genomics
 ``pbmc4k`` scRNA-seq dataset (v2 Chemistry, CellRanger 2.1.0).
 
+Trim PBMC dataset
+-----------------
+
 As a first step, we download the full dataset and generate a smaller `trimmed` copy by selecting 500 barcodes
 with high UMI count (likely non-empty) and an additional 50'000 barcodes with small UMI count (likely empty). Note
 that the trimming step is performed in order to allow us go through this tutorial in a matter of minutes on a
@@ -19,10 +22,13 @@ under your CellBender installation root directory and run the following command 
 
    $ python generate_tiny_10x_pbmc.py
 
-After successful completion of the script, you should have a new directory named `tiny_raw_gene_bc_matrices`
-containing `GRCh38/matrix.mtx`, `GRCh38/genes.tsv`, and `GRCh38/barcodes.tsv`.
+After successful completion of the script, you should have a new directory named ``tiny_raw_gene_bc_matrices``
+containing ``GRCh38/matrix.mtx``, ``GRCh38/genes.tsv``, and ``GRCh38/barcodes.tsv``.
 
-We proceed to run `remove-background` on the trimmed dataset using the following command:
+Run ``remove-background``
+-------------------------
+
+We proceed to run ``remove-background`` on the trimmed dataset using the following command:
 
 .. code-block:: bash
 
@@ -31,6 +37,9 @@ We proceed to run `remove-background` on the trimmed dataset using the following
         --output ./tiny_10x_pbmc.h5 \
         --expected-cells 500 \
         --total-droplets-included 5000
+
+Outputs
+-------
 
 The computation will finish within a minute or two (after ~ 150 epochs). The tool outputs the following files:
 
@@ -51,3 +60,82 @@ The computation will finish within a minute or two (after ~ 150 epochs). The too
 
 Finally, try running the tool with ``--expected-cells 100`` and ``--expected-cells 1000``. You should find that
 the output remains virtually the same.
+
+Use output count matrix in downstream analyses
+----------------------------------------------
+
+The count matrix that ``remove-background`` generates can be easily loaded and used for downstream analyses in
+`scanpy <https://scanpy.readthedocs.io/>`_ and `Seurat <https://satijalab.org/seurat/>`_.
+
+To load the filtered count matrix (containing only cells) into scanpy:
+
+.. code-block:: python
+
+   # import scanpy
+   import scanpy as sc
+
+   # load the data
+   adata = sc.read_10x_h5('tiny_10x_pbmc_filtered.h5', genome='background_removed')
+
+To load the filtered count matrix (containing only cells) into Seurat:
+
+.. code-block:: rd
+
+   # load Seurat (version 3) library
+   library(Seurat)
+
+   # load data from the filtered h5 file
+   data.file <- 'tiny_10x_pbmc_filtered.h5'
+   data.data <- Read10X_h5(filename = data.file, use.names = TRUE)
+
+   # create Seurat object
+   obj <- CreateSeuratObject(counts = data.data)
+
+Use latent gene expression in downstream analyses
+-------------------------------------------------
+
+To load the latent representation of gene expression ``z`` computed by ``remove-background`` in python:
+
+.. code-block:: python
+
+   import tables
+   import numpy as np
+
+   z = []
+   with tables.open_file('tiny_10x_pbmc_filtered.h5') as f:
+       print(f)  # display the structure of the h5 file
+       z = f.root.background_removed.latent_gene_encoding.read()  # read latents
+
+At this point, the variable ``z`` contains the latent encoding of gene expression, where rows are cells and
+columns are dimensions of the latent variable.  This data can be saved in CSV format with the following command:
+
+.. code-block:: python
+
+   np.savetxt('tiny_10x_pbmc_latent_gene_expression.csv', z, delimiter=',')
+
+This latent representation of gene expression can be loaded into a Seurat object ``obj`` by doing the following:
+
+.. code-block:: rd
+
+   # load the latent representation from cellbender
+   latent <- read.csv('tiny_10x_pbmc_latent_gene_expression.csv', header = FALSE)
+   latent <- t(data.matrix(latent))
+   rownames(x = latent) <- paste0("CB", 1:20)
+   colnames(x = latent) <- colnames(data.data)
+
+   # store latent as a new dimensionality reduction called 'cellbender'
+   obj[["cellbender"]] <- CreateDimReducObject(embeddings = t(latent),
+                                               key = "CB_",
+                                               assay = DefaultAssay(obj))
+
+Or the variable ``z`` (from above) can be used directly in a scanpy ``anndata`` object.  The code snippet below
+demonstrates loading the latent ``z`` and using it to do Louvain clustering:
+
+.. code-block:: python
+
+   # load the latent representation into a new slot called 'X_cellbender'
+   adata.obsm['X_cellbender'] = z
+
+   # perform louvain clustering using the cellbender latents and cosine distance
+   sc.pp.neighbors(adata, use_rep='X_cellbender', metric='cosine')
+   sc.pp.louvain(adata)

--- a/docs/source/getting_started/remove_background/index.rst
+++ b/docs/source/getting_started/remove_background/index.rst
@@ -6,9 +6,6 @@ remove-background
 In this tutorial, we will run ``remove-background`` on a small dataset derived from the 10x Genomics
 ``pbmc4k`` scRNA-seq dataset (v2 Chemistry, CellRanger 2.1.0).
 
-Trim PBMC dataset
------------------
-
 As a first step, we download the full dataset and generate a smaller `trimmed` copy by selecting 500 barcodes
 with high UMI count (likely non-empty) and an additional 50'000 barcodes with small UMI count (likely empty). Note
 that the trimming step is performed in order to allow us go through this tutorial in a matter of minutes on a
@@ -25,8 +22,8 @@ under your CellBender installation root directory and run the following command 
 After successful completion of the script, you should have a new directory named ``tiny_raw_gene_bc_matrices``
 containing ``GRCh38/matrix.mtx``, ``GRCh38/genes.tsv``, and ``GRCh38/barcodes.tsv``.
 
-Run ``remove-background``
--------------------------
+Run remove-background
+---------------------
 
 We proceed to run ``remove-background`` on the trimmed dataset using the following command:
 
@@ -37,9 +34,6 @@ We proceed to run ``remove-background`` on the trimmed dataset using the followi
         --output ./tiny_10x_pbmc.h5 \
         --expected-cells 500 \
         --total-droplets-included 5000
-
-Outputs
--------
 
 The computation will finish within a minute or two (after ~ 150 epochs). The tool outputs the following files:
 
@@ -94,7 +88,7 @@ To load the filtered count matrix (containing only cells) into Seurat:
 Use latent gene expression in downstream analyses
 -------------------------------------------------
 
-To load the latent representation of gene expression ``z`` computed by ``remove-background`` in python:
+To load the latent representation of gene expression `z` computed by ``remove-background`` using a python script:
 
 .. code-block:: python
 

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -10,7 +10,7 @@ The recommended installation is as follows. Create a conda environment and activ
 
 .. code-block:: console
 
-  $ conda create -n CellBender python=3.6
+  $ conda create -n CellBender python=3.7
   $ source activate CellBender
 
 Install the `pytables <https://www.pytables.org>`_ module:

--- a/examples/remove_background/generate_tiny_10x_pbmc.py
+++ b/examples/remove_background/generate_tiny_10x_pbmc.py
@@ -81,6 +81,9 @@ tiny_matrix_mtx = matrix_mtx.tocsr()[genes_to_keep_indices, :].tocsc()[:, barcod
 tiny_genes_df = genes_df.loc[genes_to_keep_indices]
 tiny_barcodes_df = barcodes_df.loc[barcodes_to_keep_indices]
 
+# compensate for lost counts (due to the reduced number of genes)
+tiny_matrix_mtx = tiny_matrix_mtx * int((num_raw_genes / num_genes_to_keep) ** 0.25)
+
 print(f"Number of genes in the trimmed dataset: {len(genes_to_keep_indices)}")
 print(f"Number of barcodes in the trimmed dataset: {len(barcodes_to_keep_indices)}")
 print(f"Expected number of cells in the trimmed dataset: {num_cell_barcodes_to_keep}")


### PR DESCRIPTION
Include examples of loading the tool's output into scanpy and Seurat.

Closes #13 