### PR TITLE
Remove JIT option

### DIFF
--- a/cellbender/remove_background/argparse.py
+++ b/cellbender/remove_background/argparse.py
@@ -122,10 +122,5 @@ def add_subparser_args(subparsers: argparse) -> argparse:
                            help="Training detail: learning rate for "
                                 "inference (probably "
                                 "do not exceed 1e-3).")
-    subparser.add_argument("--no-jit",
-                           dest="use_jit", action="store_false",
-                           help="Including the flag --no_jit will opt not "
-                                "to use a JIT compiler.  The JIT compiler "
-                                "provides a speed-up.")
 
     return subparsers

--- a/cellbender/remove_background/cli.py
+++ b/cellbender/remove_background/cli.py
@@ -78,6 +78,9 @@ class CLI(AbstractCLI):
         # (The same dimensions are used in reverse order for the decoder.)
         args.z_hidden_dims = sorted(args.z_hidden_dims, reverse=True)
 
+        # Set use_jit to False.
+        args.use_jit = False
+
         self.args = args
 
         return args


### PR DESCRIPTION
Remove JIT from command line options, and set use_jit to False.

Closes #28 