### PR TITLE
Setup: require sphinx>=2.1

### DIFF
--- a/REQUIREMENTS-RTD.txt
+++ b/REQUIREMENTS-RTD.txt
@@ -1,3 +1,4 @@
+sphinx>=2.1
 sphinx-rtd-theme
 sphinx-autodoc-typehints
 sphinxcontrib-programoutput

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -6,6 +6,7 @@ torch
 pyro-ppl>=0.3.2
 scikit-learn
 matplotlib
+sphinx>=2.1
 sphinx-rtd-theme
 sphinx-autodoc-typehints
 sphinxcontrib-programoutput


### PR DESCRIPTION
sphinx>=2.1 is necessary for sphinx-autodoc-typehints, which is a requirement.  This change will lead to successful installs in environments with older versions of sphinx.