### PR TITLE
Edit package requirements

### DIFF
--- a/REQUIREMENTS-RTD.txt
+++ b/REQUIREMENTS-RTD.txt
@@ -1,3 +1,4 @@
+sphinx>=2.1
 sphinx-rtd-theme
 sphinx-autodoc-typehints
 sphinxcontrib-programoutput

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -2,7 +2,6 @@ numpy
 scipy
 tables
 pandas
-torch
 pyro-ppl>=0.3.2
 scikit-learn
 matplotlib

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -6,6 +6,7 @@ torch
 pyro-ppl>=0.3.2
 scikit-learn
 matplotlib
+sphinx>=2.1
 sphinx-rtd-theme
 sphinx-autodoc-typehints
 sphinxcontrib-programoutput


### PR DESCRIPTION
`pip install` fails when an older version of `sphinx` (==1.8.5, for example) is already installed, due to `sphinx-autodoc-typehints`.  Adding the requirement `sphinx>=2.1` seems to solve this.

Also dropped the torch requirement, as Pytorch is a dependency of Pryo.