### PR TITLE
bioRxiv citation added for paper on remove-background

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,4 +75,8 @@ Citing CellBender
 -----------------
 
 If you use CellBender in your research (and we hope you will), please consider
-citing our paper on bioRxiv (the link will appear here soon).
+citing `our paper <https://www.biorxiv.org/content/10.1101/791699v1>`_:
+
+Stephen J Fleming, John C Marioni, and Mehrtash Babadi. CellBender remove-background: a deep
+generative model for unsupervised removal of background noise from scRNA-seq datasets.
+bioRxiv 791699; doi: https://doi.org/10.1101/791699

--- a/docs/source/citation/index.rst
+++ b/docs/source/citation/index.rst
@@ -3,6 +3,10 @@
 Citation
 ========
 
-If you use CellBender in your research (and we hope you will!), please consider citing our papers. The relevant
-papers to cite will be published here soon.
+If you use CellBender in your research (and we hope you will!), please consider citing our papers:
 
+`remove-background <https://www.biorxiv.org/content/10.1101/791699v1>`_:
+
+Stephen J Fleming, John C Marioni, and Mehrtash Babadi. CellBender remove-background: a deep
+generative model for unsupervised removal of background noise from scRNA-seq datasets.
+bioRxiv 791699; doi: https://doi.org/10.1101/791699


### PR DESCRIPTION
https://www.biorxiv.org/content/10.1101/791699v1

Stephen J Fleming, John C Marioni, and Mehrtash Babadi. CellBender remove-background: a deep 
generative model for unsupervised removal of background noise from scRNA-seq datasets.
bioRxiv 791699; doi: https://doi.org/10.1101/791699
