### PR TITLE
Bug fix for large transcriptomes: uint16 overflow

### DIFF
--- a/cellbender/remove_background/model.py
+++ b/cellbender/remove_background/model.py
@@ -653,7 +653,7 @@ def generate_maximum_a_posteriori_count_matrix(
 
         # Append these to their lists.
         barcodes.extend(nonzero_barcodes.astype(dtype=np.uint32))
-        genes.extend(nonzero_genes.astype(dtype=np.uint16))
+        genes.extend(nonzero_genes.astype(dtype=np.uint32))
         counts.extend(nonzero_counts.astype(dtype=np.uint32))
 
     # Convert the lists to numpy arrays.

--- a/cellbender/remove_background/model.py
+++ b/cellbender/remove_background/model.py
@@ -659,7 +659,7 @@ def generate_maximum_a_posteriori_count_matrix(
     # Convert the lists to numpy arrays.
     counts = np.array(counts, dtype=np.uint32)
     barcodes = np.array(barcodes, dtype=np.uint32)
-    genes = np.array(genes, dtype=np.uint16)
+    genes = np.array(genes, dtype=np.uint32)
 
     # Put the counts into a sparse csc_matrix.
     inferred_count_matrix = sp.csc_matrix((counts, (barcodes, genes)),


### PR DESCRIPTION
There was a bug that slipped past my notice until now:

I was using `uint16` to store gene indices for output sparse count matrices (after what I saw CellRanger doing back in early version 2).  This is a bad idea, especially for mixed-species datasets, and for newer v3 datasets which tend to just have larger transcriptomes (> 65k).  The result was a mangled output, where the count matrix would be missing some genes entirely, and their counts would be assigned to other genes.

Updating `uint16` -> `uint32` solves the problem.

Fixes #51 