### PR TITLE
remove-background version 0.2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,8 +75,8 @@ Citing CellBender
 -----------------
 
 If you use CellBender in your research (and we hope you will), please consider
-citing `our paper <https://www.biorxiv.org/content/10.1101/791699v1>`_:
+citing `our paper on bioRxiv <https://doi.org/10.1101/791699>`_.
 
-Stephen J Fleming, John C Marioni, and Mehrtash Babadi. CellBender remove-background: a deep
-generative model for unsupervised removal of background noise from scRNA-seq datasets.
-bioRxiv 791699; doi: https://doi.org/10.1101/791699
+Stephen J Fleming, John C Marioni, and Mehrtash Babadi. CellBender remove-background:
+a deep generative model for unsupervised removal of background noise from scRNA-seq
+datasets. bioRxiv 791699; doi: `https://doi.org/10.1101/791699 <https://doi.org/10.1101/791699>`_

--- a/REQUIREMENTS-DOCKER.txt
+++ b/REQUIREMENTS-DOCKER.txt
@@ -1,0 +1,8 @@
+numpy
+scipy
+tables
+pandas
+pyro-ppl>=0.3.2
+torch
+scikit-learn
+matplotlib

--- a/cellbender/remove_background/argparse.py
+++ b/cellbender/remove_background/argparse.py
@@ -54,9 +54,9 @@ def add_subparser_args(subparsers: argparse) -> argparse:
                                 "analyzed. The largest 'total_droplets' "
                                 "droplets will have their cell "
                                 "probabilities inferred as an output.")
-    subparser.add_argument("--model", nargs=None, type=str, default="full",
-                           choices=["simple", "ambient",
-                                    "swapping", "full"],
+    subparser.add_argument("--model", nargs=None, type=str,
+                           default="full",
+                           choices=["simple", "ambient", "swapping", "full"],
                            dest="model",
                            help="Which model is being used for count data. "
                                 " 'simple' does not model either ambient "
@@ -84,23 +84,21 @@ def add_subparser_args(subparsers: argparse) -> argparse:
                                 "correct prior for empty droplet counts "
                                 "in the rare case where empty counts "
                                 "are extremely high (over 200).")
-    subparser.add_argument("--z-dim", type=int, default=20,
+    subparser.add_argument("--z-dim", type=int, default=100,
                            dest="z_dim",
                            help="Dimension of latent variable z.")
     subparser.add_argument("--z-layers", nargs="+", type=int, default=[500],
                            dest="z_hidden_dims",
                            help="Dimension of hidden layers in the encoder "
                                 "for z.")
-    subparser.add_argument("--d-layers", nargs="+", type=int,
-                           default=[5, 2, 2],
-                           dest="d_hidden_dims",
-                           help="Dimension of hidden layers in the encoder "
-                                "for d.")
-    subparser.add_argument("--p-layers", nargs="+", type=int,
-                           default=[100, 10],
-                           dest="p_hidden_dims",
-                           help="Dimension of hidden layers in the encoder "
-                                "for p.")
+    subparser.add_argument("--training-fraction",
+                           type=float, nargs=None,
+                           default=consts.TRAINING_FRACTION,
+                           dest="training_fraction",
+                           help="Training detail: the fraction of the "
+                                "data used for training.  The rest is never "
+                                "seen by the inference algorithm.  Speeds up "
+                                "learning.")
     subparser.add_argument("--empty-drop-training-fraction",
                            type=float, nargs=None,
                            default=consts.FRACTION_EMPTIES,
@@ -116,11 +114,28 @@ def add_subparser_args(subparsers: argparse) -> argparse:
                                 "entirely.  In the output count matrix, "
                                 "the counts for these genes will be set "
                                 "to zero.")
+    subparser.add_argument("--fpr", nargs="+",
+                           type=float, default=[0.01],
+                           dest="fpr",
+                           help="Target false positive rate in (0, 1).  A false "
+                                "positive is a true signal count that is "
+                                "erroneously removed.  More background removal "
+                                "is accompanied by more signal removal "
+                                "at high values of FPR.  You can specify "
+                                "multiple values, which will create multiple "
+                                "output files.")
+    subparser.add_argument("--exclude-antibody-capture",
+                           dest="exclude_antibodies", action="store_true",
+                           help="Including the flag --exclude-antibody-capture "
+                                "will cause remove-background to operate on "
+                                "gene counts only, ignoring other features.")
     subparser.add_argument("--learning-rate", nargs=None,
-                           type=float, default=1e-3,
+                           type=float, default=1e-4,
                            dest="learning_rate",
-                           help="Training detail: learning rate for "
-                                "inference (probably "
+                           help="Training detail: lower learning rate for "
+                                "inference. A OneCycle learning rate schedule "
+                                "is used, where the upper learning rate is ten "
+                                "times this value. (For this value, probably "
                                 "do not exceed 1e-3).")
 
     return subparsers

--- a/cellbender/remove_background/consts.py
+++ b/cellbender/remove_background/consts.py
@@ -2,11 +2,12 @@
 
 # Factor by which the mode UMI count of the empty droplet plateau is
 # multiplied to come up with a UMI cutoff below which no barcodes are used.
-EMPIRICAL_LOW_UMI_TO_EMPTY_DROPLET_THRESHOLD = 0.8
+EMPIRICAL_LOW_UMI_TO_EMPTY_DROPLET_THRESHOLD = 0.5
 
 # Default prior for the standard deviation of the LogNormal distribution for
 # cell size, used only in the case of the 'simple' model.
 SIMPLE_MODEL_D_STD_PRIOR = 0.2
+D_STD_PRIOR = 0.02
 
 # Probability cutoff for determining which droplets contain cells and which
 # are empty.  The droplets n with inferred probability q_n > CELL_PROB_CUTOFF
@@ -21,10 +22,58 @@ LOW_UMI_CUTOFF = 15
 TOTAL_DROPLET_DEFAULT = 25000
 
 # Fraction of the data used for training (versus testing).
-TRAINING_FRACTION = 1.
+TRAINING_FRACTION = 0.9
 
 # Size of minibatch by default.
 DEFAULT_BATCH_SIZE = 128
 
 # Fraction of totally empty droplets that makes up each minibatch, by default.
 FRACTION_EMPTIES = 0.5
+
+# Prior on rho, the swapping fraction: the two concentration parameters alpha and beta.
+RHO_ALPHA_PRIOR = 18.
+RHO_BETA_PRIOR = 200.
+
+# Constraints on rho posterior latents.
+RHO_PARAM_MIN = 1.
+RHO_PARAM_MAX = 1000.
+
+# Prior on epsilon, the RT efficiency concentration parameter [Gamma(alpha, alpha)].
+EPSILON_PRIOR = 500.
+
+# Prior used for the global overdispersion parameter.
+PHI_LOC_PRIOR = 0.2
+PHI_SCALE_PRIOR = 0.2
+
+# Initial value of global latent scale for d_cell.
+D_CELL_SCALE_INIT = 0.02
+
+# Scale used to regularize values of logit cell probability (mean zero).
+P_LOGIT_SCALE = 2.
+
+# Hidden layer sizes of non-z latent encoder neural network.
+ENC_HIDDEN_DIMS = [100, 50]
+
+# False to use an approximate log_prob computation which is much faster.
+USE_EXACT_LOG_PROB = False
+
+# If using an exact log_prob computation, we integrate numerically over this size range.
+NBPC_EXACT_N_TERMS = 50
+
+# Negative binomial poisson convolution likelihood calculation: numerical safeguards.
+NBPC_MU_EPS_SAFEGAURD = 1e-10
+NBPC_ALPHA_EPS_SAFEGAURD = 1e-10
+NBPC_LAM_EPS_SAFEGAURD = 1e-10
+
+# Scale factors for loss function regularization terms: semi-supervision.
+REG_SCALE_AMBIENT_EXPRESSION = 0.01
+REG_SCALE_EMPTY_PROB = 1.0
+REG_SCALE_CELL_PROB = 10.0
+
+# Number of cells used to esitmate posterior regularization lambda. Memory hungry.
+CELLS_POSTERIOR_REG_CALC = 100
+
+# Posterior regularization constant's upper and lower bounds.
+POSTERIOR_REG_MIN = 0.1
+POSTERIOR_REG_MAX = 500
+POSTERIOR_REG_SEARCH_MAX_ITER = 20

--- a/cellbender/remove_background/data/dataset.py
+++ b/cellbender/remove_background/data/dataset.py
@@ -4,13 +4,16 @@ import tables
 import numpy as np
 import scipy.sparse as sp
 import scipy.io as io
-import cellbender.remove_background.model
-import cellbender.remove_background.consts as consts
+from scipy.stats import mode
 from sklearn.decomposition import PCA
 import torch
-from scipy.stats import mode
 
-from typing import Dict, List, Union, Tuple
+import cellbender.remove_background.model
+import cellbender.remove_background.consts as consts
+from cellbender.remove_background.infer import ProbPosterior
+from cellbender.remove_background.data.dataprep import DataLoader
+
+from typing import Dict, List, Union, Tuple, Optional
 import logging
 import os
 
@@ -32,6 +35,8 @@ class SingleCellRNACountsDataset:
         gene_blacklist: List of integer indices of genes to exclude entirely.
         low_count_threshold: Droplets with UMI counts below this number are
             excluded entirely from the analysis.
+        lambda_multiplier: Float that multiplies background estimate before
+            MAP estimation.
 
     Attributes:
         input_file: Name of data source file.
@@ -46,6 +51,9 @@ class SingleCellRNACountsDataset:
             trim_dataset_for_analysis().
         model_name: Name of model being run.
         priors: Priors estimated from the data useful for modelling.
+        posterior: Posterior estimated after inference.
+        empty_UMI_threshold: This UMI count is the maximum UMI count in the
+            user-defined surely empty droplets.
 
     Note: Count data is kept as the original, untransformed data.  Priors are
     in terms of the transformed count data.
@@ -53,13 +61,15 @@ class SingleCellRNACountsDataset:
     """
 
     def __init__(self,
-                 input_file: Union[str, None] = None,
-                 expected_cell_count: Union[int, None] = None,
+                 input_file: str,
+                 model_name: str,
+                 exclude_antibodies: bool,
+                 low_count_threshold: int,
+                 fpr: List[float],
+                 expected_cell_count: Optional[int] = None,
                  total_droplet_barcodes: int = consts.TOTAL_DROPLET_DEFAULT,
-                 fraction_empties: float = 0.5,
-                 model_name: str = None,
-                 gene_blacklist: List[int] = [],
-                 low_count_threshold: int = 30):
+                 fraction_empties: Optional[float] = None,
+                 gene_blacklist: List[int] = []):
         assert input_file is not None, "Attempting to load data, but no " \
                                        "input file was specified."
         self.input_file = input_file
@@ -67,11 +77,14 @@ class SingleCellRNACountsDataset:
         self.analyzed_gene_inds = np.array([])
         self.empty_barcode_inds = np.array([])  # Barcodes randomized each epoch
         self.data = None
+        self.exclude_antibodies = exclude_antibodies
         self.model_name = model_name
         self.fraction_empties = fraction_empties
         self.is_trimmed = False
         self.low_count_threshold = low_count_threshold
-        self.priors = {'n_cells': expected_cell_count}
+        self.priors = {'n_cells': expected_cell_count}  # Expected cells could be None.
+        self.posterior = None
+        self.fpr = fpr
         self.random = np.random.RandomState(seed=1234)
         self.EMPIRICAL_LOW_UMI_TO_EMPTY_DROPLET_THRESHOLD = \
             consts.EMPIRICAL_LOW_UMI_TO_EMPTY_DROPLET_THRESHOLD
@@ -80,9 +93,6 @@ class SingleCellRNACountsDataset:
 
         # Load the dataset.
         self._load_data()
-
-        # At first, set the cell count prior to expected cells (could be None).
-        self.priors['n_cells'] = expected_cell_count
 
         # Trim the dataset.
         self._trim_dataset_for_analysis(total_droplet_barcodes=total_droplet_barcodes,
@@ -173,8 +183,14 @@ class SingleCellRNACountsDataset:
         # Choose which genes to use based on their having nonzero counts.
         # (All barcodes must be included so that inference can generalize.)
         gene_counts_per_barcode = np.array(matrix.sum(axis=0)).squeeze()
-        self.analyzed_gene_inds = np.where(gene_counts_per_barcode
-                                           > 0)[0].astype(dtype=int)
+        if self.exclude_antibodies:
+            antibody_logic = (self.data['feature_types'] == b'Antibody Capture')
+            # Exclude these by setting their counts to zero
+            logging.info(f"Excluding {antibody_logic.sum()} features that "
+                         f"correspond to antibody capture.")
+            gene_counts_per_barcode[antibody_logic] = 0
+        nonzero_gene_counts = (gene_counts_per_barcode > 0)
+        self.analyzed_gene_inds = np.where(nonzero_gene_counts)[0].astype(dtype=int)
 
         if self.analyzed_gene_inds.size == 0:
             logging.warning("During data loading, found no genes with > 0 "
@@ -199,6 +215,9 @@ class SingleCellRNACountsDataset:
             raise AssertionError("All genes with nonzero counts have been "
                                  "blacklisted.  Examine the dataset and "
                                  "reduce the blacklist.")
+
+        logging.info(f"Including {self.analyzed_gene_inds.size} genes that have"
+                     f" nonzero counts.")
 
         # Estimate priors on cell size and 'empty' droplet size.
         self.priors['cell_counts'], self.priors['empty_counts'] = \
@@ -303,11 +322,22 @@ class SingleCellRNACountsDataset:
             self.empty_barcode_inds = empty_droplet_barcodes\
                 .astype(dtype=int)
 
+            # Find the UMI threshold for surely empty droplets.
+            last_analyzed_bc = min(cell_barcodes.size + transition_barcodes.size,
+                                   umi_count_order.size)
+            self.empty_UMI_threshold = (umi_counts[umi_count_order]
+                                        [last_analyzed_bc])
+
+            # Find the max UMI count for any cell.
+            self.max_UMI_count = umi_counts.max()
+
             logging.info(f"Using {cell_barcodes.size} probable cell "
                          f"barcodes, plus an additional "
                          f"{transition_barcodes.size} barcodes, "
                          f"and {empty_droplet_barcodes.size} empty "
                          f"droplets.")
+            logging.info(f"Largest surely-empty droplet has "
+                         f"{self.empty_UMI_threshold} UMI counts.")
 
             if ((low_UMI_count_cutoff == self.low_count_threshold)
                     and (empty_droplet_barcodes.size == 0)):
@@ -326,6 +356,8 @@ class SingleCellRNACountsDataset:
         self.priors['log_counts_crossover'] = \
             np.mean(np.log1p([self.priors['cell_counts'],
                               self.priors['empty_counts']])).item()
+
+        # TODO: overhaul estimation of d_std.  add estimate of d_empty_std
 
         # Estimate prior for the scale param of LogNormal for d.
         if self.model_name != "simple":
@@ -369,8 +401,7 @@ class SingleCellRNACountsDataset:
             # Return the count matrix for selected barcodes and genes.
             trimmed_bc_matrix = self.data['matrix'][self.analyzed_barcode_inds,
                                                     :].tocsc()
-            trimmed_matrix = trimmed_bc_matrix[:,
-                                               self.analyzed_gene_inds].tocsr()
+            trimmed_matrix = trimmed_bc_matrix[:, self.analyzed_gene_inds].tocsr()
             return trimmed_matrix
 
         else:
@@ -386,8 +417,7 @@ class SingleCellRNACountsDataset:
             # Return the count matrix for selected barcodes and genes.
             trimmed_bc_matrix = self.data['matrix'][self.empty_barcode_inds,
                                                     :].tocsc()
-            trimmed_matrix = trimmed_bc_matrix[:,
-                                               self.analyzed_gene_inds].tocsr()
+            trimmed_matrix = trimmed_bc_matrix[:, self.analyzed_gene_inds].tocsr()
             return trimmed_matrix
 
         else:
@@ -402,14 +432,44 @@ class SingleCellRNACountsDataset:
 
             # Return the count matrix for selected barcodes and genes.
             trimmed_bc_matrix = self.data['matrix'].tocsc()
-            trimmed_matrix = trimmed_bc_matrix[:,
-                                               self.analyzed_gene_inds].tocsr()
+            trimmed_matrix = trimmed_bc_matrix[:, self.analyzed_gene_inds].tocsr()
             return trimmed_matrix
 
         else:
             logging.warning("Using full count matrix, without any trimming.  "
                             "Could be slow.")
             return self.data['matrix']
+
+    def get_dataloader(self,
+                       use_cuda: bool = True,
+                       batch_size: int = 200,
+                       shuffle: bool = False,
+                       analyzed_bcs_only: bool = True) -> DataLoader:
+        """Return a dataloader for the count matrix.
+
+        Args:
+            use_cuda: Whether to load data into GPU memory.
+            batch_size: Size of minibatch of data yielded by dataloader.
+            shuffle: Whether dataloader should shuffle the data.
+            analyzed_bcs_only: Only include the barcodes that have been
+                analyzed, not the surely empty droplets.
+
+        Returns:
+            data_loader: A dataloader that yields the entire dataset in batches.
+
+        """
+
+        if analyzed_bcs_only:
+            count_matrix = self.get_count_matrix()
+        else:
+            count_matrix = self.get_count_matrix_all_barcodes()
+
+        return DataLoader(count_matrix,
+                          empty_drop_dataset=None,
+                          batch_size=batch_size,
+                          fraction_empties=0.,
+                          shuffle=shuffle,
+                          use_cuda=use_cuda)
 
     def save_to_output_file(
             self,
@@ -441,19 +501,24 @@ class SingleCellRNACountsDataset:
 
         logging.info("Preparing to write outputs to file...")
 
-        # Calculate quantities of interest from the model.
+        # Create posterior.
+        self.posterior = ProbPosterior(dataset_obj=self,
+                                       vi_model=inferred_model,
+                                       fpr=self.fpr[0])
+
         # Encoded values of latent variables.
-        z, d, p = cellbender.remove_background.model.get_encodings(
-            inferred_model, self, cells_only=True)
+        enc = self.posterior.latents
+        z = enc['z']
+        d = enc['d']
+        p = enc['p']
+        epsilon = enc['epsilon']
+        phi_params = enc['phi_loc_scale']
 
         # Estimate the ambient-background-subtracted UMI count matrix.
         if self.model_name != "simple":
 
-            inferred_count_matrix = cellbender.remove_background.model.\
-                generate_maximum_a_posteriori_count_matrix(z, d, p,
-                                                           inferred_model,
-                                                           self,
-                                                           cells_only=True)
+            inferred_count_matrix = self.posterior.mean
+
         else:
 
             # No need to generate a new count matrix for simple model.
@@ -462,18 +527,11 @@ class SingleCellRNACountsDataset:
 
         # Inferred ambient gene expression vector.
         ambient_expression_trimmed = cellbender.remove_background.model.\
-            get_ambient_expression_from_pyro_param_store()
+            get_ambient_expression()
 
         # Convert the indices from trimmed gene set to original gene indices.
         ambient_expression = np.zeros(self.data['matrix'].shape[1])
         ambient_expression[self.analyzed_gene_inds] = ambient_expression_trimmed
-
-        # Inferred contamination fraction hyperparameters.
-        rho = cellbender.remove_background.model.get_contamination_fraction()
-
-        # Inferred overdispersion hyperparameters.
-        phi = cellbender.remove_background.model.\
-            get_overdispersion_from_pyro_param_store()
 
         # Figure out the indices of barcodes that have cells.
         if p is not None:
@@ -486,63 +544,144 @@ class SingleCellRNACountsDataset:
             cell_barcode_inds = self.analyzed_barcode_inds
             filtered_inds_of_analyzed_barcodes = np.arange(0, d.size)
 
-        # Write to output file.
-        write_succeeded = write_matrix_to_cellranger_h5(
-            output_file=output_file,
-            gene_names=self.data['gene_names'],
-            gene_ids=self.data['gene_ids'],
-            barcodes=self.data['barcodes'],
-            inferred_count_matrix=inferred_count_matrix,
-            cell_barcode_inds=cell_barcode_inds,
-            ambient_expression=ambient_expression,
-            rho=rho,
-            phi=phi,
-            z=z, d=d, p=p,
-            loss=inferred_model.loss)
+        # CellRanger version (format output like input).
+        if self._detect_input_data_type() == 'cellranger_h5':
+            cellranger_version = detect_cellranger_version_h5(self.input_file)
+        else:
+            cellranger_version = detect_cellranger_version_mtx(self.input_file)
 
-        # Generate filename for filtered matrix output.
-        file_dir, file_base = os.path.split(output_file)
-        file_name = os.path.splitext(os.path.basename(file_base))[0]
-        filtered_output_file = os.path.join(file_dir,
-                                            file_name + "_filtered.h5")
-
-        # Write filtered matrix (cells only) to output file.
-        if self.model_name != "simple":
-            cell_barcode_inds = \
-                self.analyzed_barcode_inds[filtered_inds_of_analyzed_barcodes]
-
-            cell_barcodes = self.data['barcodes'][cell_barcode_inds]
-
-            write_matrix_to_cellranger_h5(
-                output_file=filtered_output_file,
+        # Write to output file, for each lambda specified by user.
+        if len(self.fpr) == 1:
+            write_succeeded = write_matrix_to_cellranger_h5(
+                cellranger_version=cellranger_version,
+                output_file=output_file,
                 gene_names=self.data['gene_names'],
                 gene_ids=self.data['gene_ids'],
-                barcodes=cell_barcodes,
-                inferred_count_matrix=inferred_count_matrix[cell_barcode_inds, :],
-                cell_barcode_inds=None,
+                feature_types=self.data['feature_types'],
+                genomes=self.data['genomes'],
+                barcodes=self.data['barcodes'],
+                inferred_count_matrix=inferred_count_matrix,
+                cell_barcode_inds=cell_barcode_inds,
                 ambient_expression=ambient_expression,
-                rho=rho,
-                phi=phi,
-                z=z[filtered_inds_of_analyzed_barcodes, :],
-                d=d[filtered_inds_of_analyzed_barcodes],
-                p=p[filtered_inds_of_analyzed_barcodes],
+                z=z, d=d, p=p, phi=phi_params, epsilon=epsilon,
+                rho=cellbender.remove_background.model.get_rho(),
+                fpr=self.fpr[0],
+                lambda_multiplier=self.posterior.lambda_multiplier,
                 loss=inferred_model.loss)
 
-            # Save barcodes determined to contain cells as _cell_barcodes.csv
-            try:
-                barcode_names = np.array([str(cell_barcodes[i],
-                                              encoding='UTF-8')
-                                          for i in range(cell_barcodes.size)])
-            except UnicodeDecodeError:
-                # necessary if barcodes are ints
-                barcode_names = cell_barcodes
-            except TypeError:
-                # necessary if barcodes are already decoded
-                barcode_names = cell_barcodes
-            bc_file_name = os.path.join(file_dir,
-                                        file_name + "_cell_barcodes.csv")
-            np.savetxt(bc_file_name, barcode_names, delimiter=',', fmt='%s')
-            logging.info(f"Saved cell barcodes in {bc_file_name}")
+            # Generate filename for filtered matrix output.
+            file_dir, file_base = os.path.split(output_file)
+            file_name = os.path.splitext(os.path.basename(file_base))[0]
+            filtered_output_file = os.path.join(file_dir, file_name + "_filtered.h5")
+
+            # Write filtered matrix (cells only) to output file.
+            if self.model_name != "simple":
+                cell_barcode_inds = \
+                    self.analyzed_barcode_inds[filtered_inds_of_analyzed_barcodes]
+
+                cell_barcodes = self.data['barcodes'][cell_barcode_inds]
+
+                write_matrix_to_cellranger_h5(
+                    cellranger_version=cellranger_version,
+                    output_file=filtered_output_file,
+                    gene_names=self.data['gene_names'],
+                    gene_ids=self.data['gene_ids'],
+                    feature_types=self.data['feature_types'],
+                    genomes=self.data['genomes'],
+                    barcodes=cell_barcodes,
+                    inferred_count_matrix=inferred_count_matrix[cell_barcode_inds, :],
+                    cell_barcode_inds=None,
+                    ambient_expression=ambient_expression,
+                    z=z[filtered_inds_of_analyzed_barcodes, :],
+                    d=d[filtered_inds_of_analyzed_barcodes],
+                    p=p[filtered_inds_of_analyzed_barcodes],
+                    phi=phi_params,
+                    epsilon=epsilon[filtered_inds_of_analyzed_barcodes],
+                    rho=cellbender.remove_background.model.get_rho(),
+                    fpr=self.fpr[0],
+                    lambda_multiplier=self.posterior.lambda_multiplier,
+                    loss=inferred_model.loss)
+
+        else:
+
+            file_dir, file_base = os.path.split(output_file)
+            file_name = os.path.splitext(os.path.basename(file_base))[0]
+
+            for i, fpr in enumerate(self.fpr):
+
+                if i > 0:  # first FPR has already been computed
+
+                    # Re-compute posterior counts for each new lambda.
+                    self.posterior.fpr = fpr  # reach in and change the FPR
+                    self.posterior._get_mean()  # force re-computation of posterior
+                    inferred_count_matrix = self.posterior.mean
+
+                # Create an output filename for this lambda value.
+                temp_output_filename = os.path.join(file_dir, file_name + f"_FPR_{fpr}.h5")
+
+                write_succeeded = write_matrix_to_cellranger_h5(
+                    cellranger_version=cellranger_version,
+                    output_file=temp_output_filename,
+                    gene_names=self.data['gene_names'],
+                    gene_ids=self.data['gene_ids'],
+                    feature_types=self.data['feature_types'],
+                    genomes=self.data['genomes'],
+                    barcodes=self.data['barcodes'],
+                    inferred_count_matrix=inferred_count_matrix,
+                    cell_barcode_inds=self.analyzed_barcode_inds,
+                    ambient_expression=ambient_expression,
+                    z=z, d=d, p=p, phi=phi_params, epsilon=epsilon,
+                    rho=cellbender.remove_background.model.get_rho(),
+                    fpr=fpr,
+                    lambda_multiplier=self.posterior.lambda_multiplier,
+                    loss=inferred_model.loss)
+
+                # Generate filename for filtered matrix output.
+                filtered_output_file = os.path.join(file_dir, file_name + f"_FPR_{fpr}_filtered.h5")
+
+                # Write filtered matrix (cells only) to output file.
+                if self.model_name != "simple":
+                    cell_barcode_inds = \
+                        self.analyzed_barcode_inds[filtered_inds_of_analyzed_barcodes]
+
+                    cell_barcodes = self.data['barcodes'][cell_barcode_inds]
+
+                    write_matrix_to_cellranger_h5(
+                        cellranger_version=cellranger_version,
+                        output_file=filtered_output_file,
+                        gene_names=self.data['gene_names'],
+                        gene_ids=self.data['gene_ids'],
+                        feature_types=self.data['feature_types'],
+                        genomes=self.data['genomes'],
+                        barcodes=cell_barcodes,
+                        inferred_count_matrix=inferred_count_matrix[cell_barcode_inds, :],
+                        cell_barcode_inds=None,
+                        ambient_expression=ambient_expression,
+                        z=z[filtered_inds_of_analyzed_barcodes, :],
+                        d=d[filtered_inds_of_analyzed_barcodes],
+                        p=p[filtered_inds_of_analyzed_barcodes],
+                        phi=phi_params,
+                        epsilon=epsilon[filtered_inds_of_analyzed_barcodes],
+                        rho=cellbender.remove_background.model.get_rho(),
+                        fpr=fpr,
+                        lambda_multiplier=self.posterior.lambda_multiplier,
+                        loss=inferred_model.loss)
+
+        # Save barcodes determined to contain cells as _cell_barcodes.csv
+        try:
+            barcode_names = np.array([str(cell_barcodes[i],
+                                          encoding='UTF-8')
+                                      for i in range(cell_barcodes.size)])
+        except UnicodeDecodeError:
+            # necessary if barcodes are ints
+            barcode_names = cell_barcodes
+        except TypeError:
+            # necessary if barcodes are already decoded
+            barcode_names = cell_barcodes
+        bc_file_name = os.path.join(file_dir,
+                                    file_name + "_cell_barcodes.csv")
+        np.savetxt(bc_file_name, barcode_names, delimiter=',', fmt='%s')
+        logging.info(f"Saved cell barcodes in {bc_file_name}")
 
         try:
             # Save plots, if called for.
@@ -555,16 +694,17 @@ class SingleCellRNACountsDataset:
                          label='Train')
 
                 # Plot the test error, if there was held-out test data.
-                if len(inferred_model.loss['test']['epoch']) > 0:
-                    plt.plot(inferred_model.loss['test']['epoch'],
-                             inferred_model.loss['test']['elbo'], 'o:',
-                             label='Test')
+                if 'test' in inferred_model.loss.keys():
+                    if len(inferred_model.loss['test']['epoch']) > 0:
+                        plt.plot(inferred_model.loss['test']['epoch'],
+                                 inferred_model.loss['test']['elbo'], 'o:',
+                                 label='Test')
+                        plt.legend()
 
                 plt.gca().set_ylim(bottom=max(inferred_model.loss['train']
                                               ['elbo'][0],
                                               inferred_model.loss['train']
                                               ['elbo'][-1] - 2000))
-                plt.legend()
                 plt.xlabel('Epoch')
                 plt.ylabel('ELBO')
                 plt.title('Progress of the training procedure')
@@ -623,7 +763,7 @@ def detect_cellranger_version_mtx(filedir: str) -> int:
 
     """
 
-    assert os.path.isdir(filedir), "The directory {filedir} is not accessible."
+    assert os.path.isdir(filedir), f"The directory {filedir} is not accessible."
 
     if os.path.isfile(os.path.join(filedir, 'features.tsv.gz')):
         return 3
@@ -667,13 +807,18 @@ def get_matrix_from_cellranger_mtx(filedir: str) \
             array contains the string names of genes in the genome, which
             correspond to the columns in the out['matrix'].
         out['gene_ids']: List of numpy arrays, where the number of elements
-            in the list is the number of genomes in the dataset.  Each numpy
-            array contains the string Ensembl ID of genes in the genome, which
-            also correspond to the columns in the out['matrix'].
+             in the list is the number of genomes in the dataset.  Each numpy
+             array contains the string Ensembl ID of genes in the genome, which
+             also correspond to the columns in the out['matrix'].
+        out['feature_types']: List of numpy arrays, where the number of elements
+             in the list is the number of genomes in the dataset.  Each numpy
+             array contains the string feature types of genes (or possibly
+             antibody capture reads), which also correspond to the columns
+             in the out['matrix'].
 
     """
 
-    assert os.path.isdir(filedir), f"The directory {filedir} is not accessible."
+    assert os.path.isdir(filedir), "The directory {filedir} is not accessible."
 
     # Decide whether data is CellRanger v2 or v3.
     cellranger_version = detect_cellranger_version_mtx(filedir=filedir)
@@ -682,45 +827,48 @@ def get_matrix_from_cellranger_mtx(filedir: str) \
     # CellRanger version 3
     if cellranger_version == 3:
 
-        matrix_file = os.path.join(filedir, "matrix.mtx.gz")
-        gene_file = os.path.join(filedir, "features.tsv.gz")
-        barcode_file = os.path.join(filedir, "barcodes.tsv.gz")
+        matrix_file = os.path.join(filedir, 'matrix.mtx.gz')
+        gene_file = os.path.join(filedir, 'features.tsv.gz')
+        barcode_file = os.path.join(filedir, 'barcodes.tsv.gz')
 
         # Read in feature names.
         features = np.genfromtxt(fname=gene_file,
-                                 delimiter="\t", skip_header=0, dtype='<U50')
+                                 delimiter="\t", skip_header=0,
+                                 dtype='<U100')
 
-        # Restrict to gene expression only.
-        is_gene_expression = (features[:, 2] == "Gene Expression")
-        gene_info = features[is_gene_expression]
-        gene_names = gene_info[:, 1].squeeze()  # second column
-        gene_ids = gene_info[:, 0].squeeze()  # first column
-
-        # Read in sparse count matrix.
-        count_matrix = io.mmread(matrix_file).tocsr().transpose()
-
-        # Excise other 'features' from the count matrix
-        gene_feature_inds = np.where(is_gene_expression)[0]
-        count_matrix = count_matrix[:, gene_feature_inds]
+        # Read in gene expression and feature data.
+        gene_ids = features[:, 0].squeeze()  # first column
+        gene_names = features[:, 1].squeeze()  # second column
+        feature_types = features[:, 2].squeeze()  # third column
 
     # CellRanger version 2
     elif cellranger_version == 2:
 
         # Read in the count matrix using scipy.
-        matrix_file = os.path.join(filedir, "matrix.mtx")
+        matrix_file = os.path.join(filedir, 'matrix.mtx')
         gene_file = os.path.join(filedir, "genes.tsv")
         barcode_file = os.path.join(filedir, "barcodes.tsv")
 
         # Read in gene names.
-        gene_info = np.genfromtxt(fname=gene_file,
-                                  delimiter="\t", skip_header=0, dtype='<U50')
-        gene_names = gene_info[:, 1].squeeze()  # second column
-        gene_ids = gene_info[:, 0].squeeze()  # first column
+        gene_data = np.genfromtxt(fname=gene_file,
+                                  delimiter="\t", skip_header=0,
+                                  dtype='<U100')
+        if len(gene_data.shape) == 1:  # custom file format with just gene names
+            gene_names = gene_data.squeeze()
+            gene_ids = None
+        else:  # the 10x CellRanger v2 format with two columns
+            gene_names = gene_data[:, 1].squeeze()  # second column
+            gene_ids = gene_data[:, 0].squeeze()  # first column
+        feature_types = None
 
-        # Read in sparse count matrix.
-        count_matrix = io.mmread(matrix_file).tocsr().transpose()
+    else:
+        raise NotImplementedError('MTX format was not identifiable as CellRanger '
+                                  'v2 or v3.  Please check 10x Genomics formatting.')
 
     # For both versions:
+
+    # Read in sparse count matrix.
+    count_matrix = io.mmread(matrix_file).tocsr().transpose()
 
     # Read in barcode names.
     barcodes = np.genfromtxt(fname=barcode_file,
@@ -738,7 +886,9 @@ def get_matrix_from_cellranger_mtx(filedir: str) \
 
     return {'matrix': count_matrix,
             'gene_names': gene_names,
+            'feature_types': feature_types,
             'gene_ids': gene_ids,
+            'genomes': None,  # TODO: check if this info is available in either version
             'barcodes': barcodes}
 
 
@@ -800,9 +950,14 @@ def get_matrix_from_cellranger_h5(filename: str) \
             array contains the string names of genes in the genome, which
             correspond to the columns in the out['matrix'].
         out['gene_ids']: List of numpy arrays, where the number of elements
-            in the list is the number of genomes in the dataset.  Each numpy
-            array contains the string Ensembl ID of genes in the genome, which
-            also correspond to the columns in the out['matrix'].
+             in the list is the number of genomes in the dataset.  Each numpy
+             array contains the string Ensembl ID of genes in the genome, which
+             also correspond to the columns in the out['matrix'].
+        out['feature_types']: List of numpy arrays, where the number of elements
+             in the list is the number of genomes in the dataset.  Each numpy
+             array contains the string feature types of genes (or possibly
+             antibody capture reads), which also correspond to the columns
+             in the out['matrix'].
 
     """
 
@@ -812,15 +967,19 @@ def get_matrix_from_cellranger_h5(filename: str) \
 
     with tables.open_file(filename, 'r') as f:
         # Initialize empty lists.
-        gene_names = []
-        gene_ids = []
         csc_list = []
         barcodes = None
+        feature_ids = None
+        feature_types = None
+        genomes = None
 
         # CellRanger v2:
         # Each group in the table (other than root) contains a genome,
         # so walk through the groups to get data for each genome.
         if cellranger_version == 2:
+
+            feature_names = []
+            feature_ids = []
 
             for group in f.walk_groups():
                 try:
@@ -833,12 +992,19 @@ def get_matrix_from_cellranger_h5(filename: str) \
                     shape = getattr(group, 'shape').read()
                     csc_list.append(sp.csc_matrix((data, indices, indptr),
                                                   shape=shape))
-                    gene_names.extend(getattr(group, 'gene_names').read())
-                    gene_ids.extend(getattr(group, 'genes').read())
+                    feature_names.extend(getattr(group, 'gene_names').read())
+                    feature_ids.extend(getattr(group, 'genes').read())
 
                 except tables.NoSuchNodeError:
                     # This exists to bypass the root node, which has no data.
                     pass
+
+            # Create numpy arrays.
+            feature_names = np.array(feature_names)
+            if len(feature_ids) > 0:
+                feature_ids = np.array(feature_ids)
+            else:
+                feature_ids = None
 
         # CellRanger v3:
         # There is only the 'matrix' group.
@@ -856,58 +1022,76 @@ def get_matrix_from_cellranger_h5(filename: str) \
 
             # Read in 'feature' information
             feature_group = f.get_node(f.root.matrix, 'features')
-            feature_types = getattr(feature_group,
-                                    'feature_type').read()
             feature_names = getattr(feature_group, 'name').read()
-            feature_ids = getattr(feature_group, 'id').read()
 
-            # The only 'feature' we want is 'Gene Expression'
-            is_gene_expression = (feature_types == b'Gene Expression')
-            gene_names.extend(feature_names[is_gene_expression])
-            gene_ids.extend(feature_ids[is_gene_expression])
-
-            # Excise other 'features' from the count matrix
-            gene_feature_inds = np.where(is_gene_expression)[0]
-            csc_list[-1] = csc_list[-1][gene_feature_inds, :]
+            try:
+                feature_types = getattr(feature_group, 'feature_type').read()
+            except tables.NoSuchNodeError:
+                # This exists in case someone produced a file without feature_type.
+                pass
+            try:
+                feature_ids = getattr(feature_group, 'id').read()
+            except tables.NoSuchNodeError:
+                # This exists in case someone produced a file without feature id.
+                pass
+            try:
+                genomes = getattr(feature_group, 'genome').read()
+            except tables.NoSuchNodeError:
+                # This exists in case someone produced a file without feature genome.
+                pass
 
     # Put the data together (possibly from several genomes for v2 datasets).
     count_matrix = sp.vstack(csc_list, format='csc')
     count_matrix = count_matrix.transpose().tocsr()
 
     # Issue warnings if necessary, based on dimensions matching.
-    if count_matrix.shape[1] != len(gene_names):
-        logging.warning(f"Number of gene names in {filename} does not match "
-                        f"the number expected from the count matrix.")
-    if count_matrix.shape[0] != len(barcodes):
-        logging.warning(f"Number of barcodes in {filename} does not match "
-                        f"the number expected from the count matrix.")
+    if count_matrix.shape[1] != feature_names.size:
+        logging.warning(f"Number of gene names ({feature_names.size}) in {filename} "
+                        f"does not match the number expected from the count "
+                        f"matrix ({count_matrix.shape[1]}).")
+    if count_matrix.shape[0] != barcodes.size:
+        logging.warning(f"Number of barcodes ({barcodes.size}) in {filename} "
+                        f"does not match the number expected from the count "
+                        f"matrix ({count_matrix.shape[0]}).")
 
     return {'matrix': count_matrix,
-            'gene_names': np.array(gene_names),
-            'gene_ids': np.array(gene_ids),
-            'barcodes': np.array(barcodes)}
+            'gene_names': feature_names,
+            'gene_ids': feature_ids,
+            'genomes': genomes,
+            'feature_types': feature_types,
+            'barcodes': barcodes}
 
 
 def write_matrix_to_cellranger_h5(
+        cellranger_version: int,
         output_file: str,
         gene_names: np.ndarray,
-        gene_ids: np.ndarray,
         barcodes: np.ndarray,
         inferred_count_matrix: sp.csc.csc_matrix,
-        cell_barcode_inds: Union[np.ndarray, None] = None,
-        ambient_expression: Union[np.ndarray, None] = None,
-        rho: Union[np.ndarray, None] = None,
-        phi: Union[np.ndarray, None] = None,
-        z: Union[np.ndarray, None] = None,
-        d: Union[np.ndarray, None] = None,
-        p: Union[np.ndarray, None] = None,
-        loss: Union[Dict, None] = None) -> bool:
+        feature_types: Optional[np.ndarray] = None,
+        gene_ids: Optional[np.ndarray] = None,
+        genomes: Optional[np.ndarray] = None,
+        cell_barcode_inds: Optional[np.ndarray] = None,
+        ambient_expression: Optional[np.ndarray] = None,
+        rho: Optional[np.ndarray] = None,
+        z: Optional[np.ndarray] = None,
+        d: Optional[np.ndarray] = None,
+        p: Optional[np.ndarray] = None,
+        phi: Optional[np.ndarray] = None,
+        epsilon: Optional[np.ndarray] = None,
+        fpr: Optional[float] = None,
+        lambda_multiplier: Optional[float] = None,
+        loss: Optional[Dict] = None) -> bool:
     """Write count matrix data to output HDF5 file using CellRanger format.
 
     Args:
+        cellranger_version: Either 2 or 3. Determines the format of the output
+            h5 file.
         output_file: Path to output .h5 file (e.g., 'output.h5').
         gene_names: Name of each gene (column of count matrix).
         gene_ids: Ensembl ID of each gene (column of count matrix).
+        genomes: Name of the genome that each gene comes from.
+        feature_types: Type of each feature (column of count matrix).
         barcodes: Name of each barcode (row of count matrix).
         inferred_count_matrix: Count matrix to be written to file, in sparse
             format.  Rows are barcodes, columns are genes.
@@ -916,10 +1100,16 @@ def write_matrix_to_cellranger_h5(
         ambient_expression: Vector of gene expression of the ambient RNA
             background counts that contaminate cell counts.
         rho: Hyperparameters for the contamination fraction distribution.
-        phi: Hyperparameters for the overdispersion distribution.
+        epsilon: Latent encoding of droplet RT efficiency.
         z: Latent encoding of gene expression.
-        d: Latent encoding of cell size scale factor.
-        p: Latent encoding of the probability that a barcode contains a cell.
+        d: Latent cell size scale factor.
+        p: Latent probability that a barcode contains a cell.
+        phi: Latent global overdispersion mean and scale.
+        fpr: Target false positive rate for the regularized posterior denoised
+            counts, where false positives are true counts that are (erroneously)
+            removed.
+        lambda_multiplier: The lambda multiplier value used to achieve the
+            targeted false positive rate.
         loss: Training and test error, as ELBO, for each epoch.
 
     Note:
@@ -936,8 +1126,19 @@ def write_matrix_to_cellranger_h5(
         "The number of gene names must match the number of columns in the " \
         "count matrix."
 
-    assert gene_names.size == gene_ids.size, \
-        "The number of gene_names must match the number of gene_ids."
+    if gene_ids is not None:
+        assert gene_names.size == gene_ids.size, \
+            f"The number of gene_names {gene_names.shape} must match " \
+            f"the number of gene_ids {gene_ids.shape}."
+
+    if feature_types is not None:
+        assert gene_names.size == feature_types.size, \
+            f"The number of gene_names {gene_names.shape} must match " \
+            f"the number of feature_types {feature_types.shape}."
+
+    if genomes is not None:
+        assert gene_names.size == genomes.size, \
+            "The number of gene_names must match the number of genome designations."
 
     assert barcodes.size == inferred_count_matrix.shape[0], \
         "The number of barcodes must match the number of rows in the count" \
@@ -949,15 +1150,48 @@ def write_matrix_to_cellranger_h5(
     # Write to output file.
     try:
         with tables.open_file(output_file, "w",
-                              title="Background-subtracted UMI counts") as f:
+                              title="CellBender remove-background output") as f:
 
-            # Create the group where data will be stored.
-            group = f.create_group("/", "background_removed",
-                                   "Counts after background correction")
+            if cellranger_version == 2:
 
-            # Create arrays within that group for barcodes and gene_names.
-            f.create_array(group, "gene_names", gene_names)
-            f.create_array(group, "genes", gene_ids)
+                # Create the group where data will be stored.
+                group = f.create_group("/", "background_removed",
+                                       "Counts after background correction")
+
+                # Create arrays within that group for gene info.
+                f.create_array(group, "gene_names", gene_names)
+                if gene_ids is not None:
+                    f.create_array(group, "genes", gene_ids)
+
+            elif cellranger_version == 3:
+
+                # Create the group where data will be stored: name is "matrix".
+                group = f.create_group("/", "matrix",
+                                       "Counts after background correction")
+
+                # Create a sub-group called "features"
+                feature_group = f.create_group(group, "features",
+                                               "Genes and other features measured")
+
+                # Create arrays within that group for feature info.
+                f.create_array(feature_group, "name", gene_names)
+                if gene_ids is not None:
+                    f.create_array(feature_group, "id", gene_ids)
+                if feature_types is not None:
+                    f.create_array(feature_group, "feature_type", feature_types)
+                if genomes is not None:
+                    f.create_array(feature_group, "genome", genomes)
+
+                # Copy the other extraneous information from the input file.
+                # (Some user might need it for some reason.)
+                # TODO
+
+            else:
+                raise NotImplementedError(f'Trying to save to CellRanger '
+                                          f'v{cellranger_version} format, which '
+                                          f'is not implemented.')
+
+            # Code for both versions.
             f.create_array(group, "barcodes", barcodes)
 
             # Create arrays to store the count data.
@@ -978,15 +1212,29 @@ def write_matrix_to_cellranger_h5(
                 f.create_array(group, "latent_scale", d)
             if p is not None:
                 f.create_array(group, "latent_cell_probability", p)
+            if phi is not None:
+                f.create_array(group, "overdispersion_mean_and_scale", phi)
             if rho is not None:
                 f.create_array(group, "contamination_fraction_params", rho)
-            if phi is not None:
-                f.create_array(group, "overdispersion_params", phi)
+            if epsilon is not None:
+                f.create_array(group, "latent_RT_efficiency", epsilon)
+            if fpr is not None:
+                f.create_array(group, "target_false_positive_rate", fpr)
+            if lambda_multiplier is not None:
+                f.create_array(group, "lambda_multiplier", lambda_multiplier)
             if loss is not None:
                 f.create_array(group, "training_elbo_per_epoch",
                                np.array(loss['train']['elbo']))
+                if 'test' in loss.keys():
+                    f.create_array(group, "test_elbo",
+                                   np.array(loss['test']['elbo']))
+                    f.create_array(group, "test_epoch",
+                                   np.array(loss['test']['epoch']))
+                    f.create_array(group, "fraction_data_used_for_testing",
+                                   1. - consts.TRAINING_FRACTION)
 
-        logging.info(f"Succeeded in writing output to file {output_file}")
+        logging.info(f"Succeeded in writing CellRanger v{cellranger_version} "
+                     f"format output to file {output_file}")
 
         return True
 
@@ -1058,10 +1306,21 @@ def get_d_priors_from_dataset(dataset: SingleCellRNACountsDataset) \
 
         # Estimate the number of UMI counts in cells.
 
-        # Median of log counts above 5 * empty counts is a robust
-        # cell estimator.
-        cell_log_counts = np.median(np.log1p(counts[counts > 5 * empty_counts]))
-        cell_counts = int(np.expm1(cell_log_counts).item())
+        # Use expected cells if it is available.
+        if dataset.priors['n_cells'] is not None:
+
+            # Sort order the cells by counts.
+            sort_order = np.argsort(counts)[::-1]
+
+            cell_counts = int(np.median(counts[sort_order]
+                                        [:dataset.priors['n_cells']]).item())
+
+        else:
+
+            # Median of log counts above 5 * empty counts is a robust
+            # cell estimator.
+            cell_log_counts = np.median(np.log1p(counts[counts > 5 * empty_counts]))
+            cell_counts = int(np.expm1(cell_log_counts).item())
 
         logging.info(f"Prior on counts in empty droplets is {empty_counts}")
 
@@ -1138,7 +1397,7 @@ def estimate_chi_ambient_from_dataset(dataset: SingleCellRNACountsDataset) \
     count_matrix = dataset.get_count_matrix()
 
     # Empty droplets have log counts < log_crossover.
-    empty_barcodes = (np.log(np.array(count_matrix.sum(axis=1)).squeeze())
+    empty_barcodes = (np.log1p(np.array(count_matrix.sum(axis=1)).squeeze())
                       < log_crossover)
 
     # Sum gene expression for the empty droplets.

--- a/cellbender/remove_background/distributions/NegativeBinomialPoissonConv.py
+++ b/cellbender/remove_background/distributions/NegativeBinomialPoissonConv.py
@@ -1,0 +1,172 @@
+import pyro.distributions as dist
+
+import torch
+import torch.nn.functional as F
+from torch.distributions import constraints
+from torch.distributions.distribution import Distribution
+from torch.distributions.utils import \
+    broadcast_all, probs_to_logits, lazy_property, logits_to_probs
+
+from numbers import Number
+
+
+class TorchNegativeBinomialPoissonConv(Distribution):
+    r"""
+    Creates a distribution for a random variable Z = X + Y such that:
+
+        X ~ NegativeBinomial(:attr:`mu`, :attr:`alpha`)
+        Y ~ Poisson(:attr:`lam`)
+
+    where :attr:`mu` is the mean of X, `alpha` is the inverse of the overdispersion of X, and
+    :attr:`lam` is the rate of Y.
+
+    Args:
+        mu (Number, Tensor): mean of the negative binomial variable
+        alpha (Number, Tensor): inverse overdispersion of the negative binomial variable
+        lam (Number, Tensor): rate of the Poisson variable
+    """
+    arg_constraints = {'mu': constraints.positive,
+                       'alpha': constraints.positive,
+                       'lam': constraints.positive}
+    support = constraints.nonnegative_integer
+
+    def __init__(self, mu, alpha, lam, max_poisson, validate_args=None):
+        assert isinstance(max_poisson, int)
+        self.mu, self.alpha, self.lam = broadcast_all(mu, alpha, lam)
+        self.max_poisson = max_poisson
+        self.neg_inf = torch.Tensor([float("-inf")]).to(device=mu.device)
+        if isinstance(mu, Number) and isinstance(alpha, Number) \
+                and isinstance(lam, Number):
+            batch_shape = torch.Size()
+        else:
+            batch_shape = self.mu.size()
+        super(TorchNegativeBinomialPoissonConv,
+              self).__init__(batch_shape, validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(TorchNegativeBinomialPoissonConv,
+                                         _instance)
+        batch_shape = torch.Size(batch_shape)
+        new.mu = self.mu.expand(batch_shape)
+        new.alpha = self.alpha.expand(batch_shape)
+        new.lam = self.lam.expand(batch_shape)
+        new.max_poisson = self.max_poisson
+        new.neg_inf = self.neg_inf
+
+        super(TorchNegativeBinomialPoissonConv,
+              new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
+    @staticmethod
+    def _poisson_log_prob(lam, value):
+        return (lam.log() * value) - lam - (value + 1).lgamma()
+
+    @staticmethod
+    def _neg_binom_log_prob(mu, alpha, value):
+        return ((value + alpha).lgamma() - (value + 1).lgamma() - alpha.lgamma()
+                + alpha * (alpha.log() - (alpha + mu).log())
+                + value * (mu.log() - (alpha + mu).log()))
+
+    @staticmethod
+    def _poisson_log_prob_zero(lam):
+        return - lam
+
+    @staticmethod
+    def _neg_binom_log_prob_zero(mu, alpha):
+        return alpha * (alpha.log() - (alpha + mu).log())
+
+    @staticmethod
+    def _poisson_log_prob_one(lam):
+        return lam.log() - lam
+
+    @staticmethod
+    def _neg_binom_log_prob_one(mu, alpha):
+        # log_gamma(2.) = 0
+        # log_gamma(z + 1) - log_gamma(z) = ln(z)
+        return (alpha + 1) * (alpha.log() - (alpha + mu).log()) + mu.log()
+
+    @staticmethod
+    def _gamma_log_prob(alpha, beta, value):
+        return (alpha * beta.log() +
+                (alpha - 1) * value.log() -
+                beta * value - alpha.lgamma())
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        mu, alpha, lam, value = broadcast_all(self.mu, self.alpha, self.lam, value)
+
+        # let us treat the assumed-to-be-prevalent edge case of value = 0 more efficiently
+        zero_indices = (value == 0)
+        poisson_log_prob_zero = self._poisson_log_prob_zero(lam[zero_indices])
+        neg_binom_log_prob_zero = self._neg_binom_log_prob_zero(mu[zero_indices],
+                                                                alpha[zero_indices])
+        total_log_prob_zero = poisson_log_prob_zero + neg_binom_log_prob_zero
+
+        # let us treat the assumed-to-be-prevalent edge case of value = 1 more efficiently
+        one_indices = (value == 1)
+        poisson_log_prob_zero = self._poisson_log_prob_zero(lam[one_indices])
+        neg_binom_log_prob_zero = self._neg_binom_log_prob_zero(mu[one_indices],
+                                                                alpha[one_indices])
+        poisson_log_prob_one = self._poisson_log_prob_one(lam[one_indices])
+        neg_binom_log_prob_one = self._neg_binom_log_prob_one(mu[one_indices],
+                                                              alpha[one_indices])
+        total_log_prob_one = torch.logsumexp(
+            torch.cat(((poisson_log_prob_zero + neg_binom_log_prob_one).unsqueeze(-1),
+                       (poisson_log_prob_one + neg_binom_log_prob_zero).unsqueeze(-1)), dim=-1),
+            dim=-1, keepdim=False)
+
+        # set up tables to perform complete numerical convolution on values > 1
+        summation_indices = (value > 1)
+        summation_obs = value[summation_indices]
+
+        # estimate a reasonable low-end to begin the Poisson summation
+        poisson_values_low = (lam.detach()[summation_indices] - self.max_poisson / 2).int()
+        poisson_values_low = torch.clamp(torch.min(poisson_values_low,
+                                                   (summation_obs
+                                                    - self.max_poisson).int()), min=0)
+
+        increment_values = torch.arange(
+            0, self.max_poisson + 1, dtype=value.dtype,
+            device=value.device).expand(summation_obs.shape + (-1,))
+        poisson_values = poisson_values_low.unsqueeze(-1) + increment_values
+        nb_values = summation_obs.unsqueeze(-1) - poisson_values
+
+        # clamp nb_values to positive values
+        inf_mask = (nb_values < 0)
+        nb_values = torch.clamp(nb_values, min=0)
+
+        # calculate poisson and negative binomial log probs on forward and backward counts
+        poisson_log_prob_rest = self._poisson_log_prob(lam[summation_indices].unsqueeze(-1),
+                                                       poisson_values.float())
+        neg_binom_log_prob_rest = self._neg_binom_log_prob(mu[summation_indices].unsqueeze(-1),
+                                                           alpha[summation_indices].unsqueeze(-1),
+                                                           nb_values.float())
+        total_log_prob_rest = poisson_log_prob_rest + neg_binom_log_prob_rest
+
+        # set out-of-range values to -inf
+        # total_log_prob_nnz[inf_mask] = float("-inf")  # this is doing a deep copy
+        total_log_prob_rest = torch.where(inf_mask,
+                                          self.neg_inf,
+                                          total_log_prob_rest)
+
+        total_log_prob_rest = torch.logsumexp(total_log_prob_rest,
+                                              dim=-1,
+                                              keepdim=False)
+
+        out = torch.empty_like(value)
+        out[zero_indices] = total_log_prob_zero  # deep copy
+        out[one_indices] = total_log_prob_one  # deep copy
+        out[summation_indices] = total_log_prob_rest  # deep copy
+
+        return out
+
+
+# We wrap the Torch distribution inside a Pyro distribution.
+# This is as simple as inheriting
+# distributions.torch_distribution.TorchDistributionMixin.
+# It adds the required extra attributes.
+class NegativeBinomialPoissonConv(TorchNegativeBinomialPoissonConv,
+                                  dist.torch_distribution.TorchDistributionMixin):
+    pass

--- a/cellbender/remove_background/distributions/NegativeBinomialPoissonConvApprox.py
+++ b/cellbender/remove_background/distributions/NegativeBinomialPoissonConvApprox.py
@@ -1,0 +1,152 @@
+import pyro.distributions as dist
+
+import torch
+from torch.distributions import constraints
+from torch.distributions.distribution import Distribution
+from torch.distributions.utils import broadcast_all
+
+from numbers import Number
+from cellbender.remove_background.exceptions import NanException
+
+
+class TorchNegativeBinomialPoissonConvApprox(Distribution):
+    r"""
+    Creates a distribution for a random variable Z = X + Y such that:
+
+        X ~ NegativeBinomial(:attr:`mu`, :attr:`alpha`)
+        Y ~ Poisson(:attr:`lam`)
+
+    where :attr:`mu` is the mean of X, `alpha` is the inverse of the overdispersion of X, and
+    :attr:`lam` is the rate of Y.
+
+    For computational efficiency, the log_prob is computed as follows:
+    We approximate the convolution with a negative binomial by moment matching.
+        For entries of mu >= 1e-5, we use NB(mu_hat, alpha_hat).log_prob, where
+        mu_hat = mu + lambda
+        alpha_hat = (mu_hat / mu)^2 * alpha
+        For entries where mu < 1e-5, we use approximate mu --> zero, and so the
+        convolution reverts to Poisson(lambda).log_prob
+
+    Args:
+        mu (Number, Tensor): mean of the negative binomial variable
+        alpha (Number, Tensor): inverse overdispersion of the negative binomial variable
+        lam (Number, Tensor): rate of the Poisson variable
+    """
+    arg_constraints = {'mu': constraints.positive,
+                       'alpha': constraints.positive,
+                       'lam': constraints.positive}
+    support = constraints.nonnegative_integer
+
+    def __init__(self, mu, alpha, lam, validate_args=None):
+        self.mu, self.alpha, self.lam = broadcast_all(mu, alpha, lam)
+        if isinstance(mu, Number) and isinstance(alpha, Number) \
+                and isinstance(lam, Number):
+            batch_shape = torch.Size()
+        else:
+            batch_shape = self.mu.size()
+        super(TorchNegativeBinomialPoissonConvApprox,
+              self).__init__(batch_shape, validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(TorchNegativeBinomialPoissonConvApprox,
+                                         _instance)
+        batch_shape = torch.Size(batch_shape)
+        new.mu = self.mu.expand(batch_shape)
+        new.alpha = self.alpha.expand(batch_shape)
+        new.lam = self.lam.expand(batch_shape)
+
+        super(TorchNegativeBinomialPoissonConvApprox,
+              new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
+    @staticmethod
+    def _poisson_log_prob(lam, value):
+        return (lam.log() * value) - lam - (value + 1).lgamma()
+
+    @staticmethod
+    def _neg_binom_log_prob(mu, alpha, value):
+        return ((value + alpha).lgamma() - (value + 1).lgamma() - alpha.lgamma()
+                + alpha * (alpha.log() - (alpha + mu).log())
+                + value * (mu.log() - (alpha + mu).log()))
+
+    @staticmethod
+    def _poisson_log_prob_zero(lam):
+        return - lam
+
+    @staticmethod
+    def _neg_binom_log_prob_zero(mu, alpha):
+        return alpha * (alpha.log() - (alpha + mu).log())
+
+    @staticmethod
+    def _poisson_log_prob_one(lam):
+        return lam.log() - lam
+
+    @staticmethod
+    def _neg_binom_log_prob_one(mu, alpha):
+        # log_gamma(2.) = 0
+        # log_gamma(z + 1) - log_gamma(z) = ln(z)
+        return (alpha + 1) * (alpha.log() - (alpha + mu).log()) + mu.log()
+
+    @staticmethod
+    def _poisson_log_prob_two(lam):
+        return 2. * lam.log() - lam - 0.69314718  # ln(2)
+
+    @staticmethod
+    def _neg_binom_log_prob_two(mu, alpha):
+        # log_gamma(3.) = 0.6931 = ln(2.)
+        return ((2. + alpha).lgamma() - 0.69314718 - alpha.lgamma()
+                + alpha * (alpha.log() - (alpha + mu).log())
+                + 2. * (mu.log() - (alpha + mu).log()))
+
+    def log_prob(self, value):
+        """Empirically, it seems that a moment-matched negative binomial is a
+        sufficient approximation except for when value = 1 or 2.
+        In those cases, we can do a brute-force computation, and the result is
+        quite close to the full brute-force computation.
+        """
+        if self._validate_args:
+            self._validate_sample(value)
+        # mu, alpha, lam, value = broadcast_all(self.mu, self.alpha, self.lam, value)
+        mu, lam, value = broadcast_all(self.mu, self.lam, value)
+
+        # Use a moment-matched negative binomial approximation.
+        mean_hat = mu + lam
+        alpha_hat = mean_hat.pow(2) * self.alpha * mu.pow(-2)
+        nb_approx_log_prob = self._neg_binom_log_prob(mu=mean_hat,
+                                                      alpha=alpha_hat,
+                                                      value=value)
+
+        # Use a poisson for small mu, where the above approximation is bad.
+        empty_indices = (mu < 1e-5)
+        poisson_log_prob = self._poisson_log_prob(lam=lam[empty_indices],
+                                                  value=value[empty_indices])
+
+        # Replace small mu log_prob values.
+        log_prob = nb_approx_log_prob
+        log_prob[empty_indices] = poisson_log_prob  # Deep copy, but it's faster
+
+        # NaN check!  Checking here prevents us from taking a bad gradient step.
+        if torch.isnan(log_prob.sum()):
+            param = []
+            if torch.isnan(mu.log().sum()):
+                param.append('mu')
+                print(f'mu problem values: {mu[torch.isnan(mu.log())]}')
+            if torch.isnan(self.alpha.log().sum()):
+                param.append('alpha')
+                print(f'alpha value: {self.alpha}')
+            if torch.isnan(lam.log().sum()):
+                param.append('lam')
+                print(f'lam problem values: {lam[torch.isnan(lam.log())]}')
+            raise NanException(param=', '.join(param))
+
+        return log_prob
+
+
+# We wrap the Torch distribution inside a Pyro distribution.
+# This is as simple as inheriting
+# distributions.torch_distribution.TorchDistributionMixin.
+# It adds the required extra attributes.
+class NegativeBinomialPoissonConvApprox(TorchNegativeBinomialPoissonConvApprox,
+                                        dist.torch_distribution.TorchDistributionMixin):
+    pass

--- a/cellbender/remove_background/distributions/NullDist.py
+++ b/cellbender/remove_background/distributions/NullDist.py
@@ -1,0 +1,68 @@
+import numbers
+
+import torch
+from torch.distributions import constraints
+
+from pyro.distributions.torch_distribution import TorchDistribution
+
+
+class NullDist(TorchDistribution):
+    """
+    This is pyro.distributions.delta that returns 0 for log_prob.
+    Degenerate discrete distribution (a single point).
+
+    Note: This distribution can be used as a work-around to pass back values
+    from guide to model.
+
+    :param torch.Tensor v: The single support element.
+    :param torch.Tensor log_density: An optional density for this Delta. This
+        is useful to keep the class of :class:`Delta` distributions closed
+        under differentiable transformation.
+    :param int event_dim: Optional event dimension, defaults to zero.
+    """
+    has_rsample = True
+    arg_constraints = {'v': constraints.real, 'log_density': constraints.real}
+    support = constraints.real
+
+    def __init__(self, v, log_density=0.0, event_dim=0, validate_args=None):
+        if event_dim > v.dim():
+            raise ValueError('Expected event_dim <= v.dim(), actual '
+                             '{} vs {}'.format(event_dim, v.dim()))
+        batch_dim = v.dim() - event_dim
+        batch_shape = v.shape[:batch_dim]
+        event_shape = v.shape[batch_dim:]
+        if isinstance(log_density, numbers.Number):
+            log_density = torch.full(batch_shape, log_density,
+                                     dtype=v.dtype, device=v.device)
+        elif validate_args and log_density.shape != batch_shape:
+            raise ValueError('Expected log_density.shape = {}, actual {}'.format(
+                log_density.shape, batch_shape))
+        self.v = v
+        self.log_density = log_density
+        super(NullDist, self).__init__(batch_shape, event_shape,
+                                       validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(NullDist, _instance)
+        batch_shape = torch.Size(batch_shape)
+        new.v = self.v.expand(batch_shape + self.event_shape)
+        new.log_density = self.log_density.expand(batch_shape)
+        super(NullDist, new).__init__(batch_shape, self.event_shape,
+                                      validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = sample_shape + self.v.shape
+        return self.v.expand(shape)
+
+    def log_prob(self, x):
+        return torch.zeros_like(x)
+
+    @property
+    def mean(self):
+        return self.v
+
+    @property
+    def variance(self):
+        return torch.zeros_like(self.v)

--- a/cellbender/remove_background/exceptions.py
+++ b/cellbender/remove_background/exceptions.py
@@ -1,0 +1,13 @@
+# Exceptions defined by CellBender
+
+
+class NanException(ArithmeticError):
+    """Exception raised when a NaN is present.
+
+    Attributes:
+        param: Name of parameter(s) causing / containing the NaN
+    """
+
+    def __init__(self, param: str):
+        self.param = param
+        self.message = 'A wild NaN appeared!  In param {' + self.param + '}'

--- a/cellbender/remove_background/infer.py
+++ b/cellbender/remove_background/infer.py
@@ -1,0 +1,777 @@
+# Posterior inference.
+
+import pyro
+import pyro.distributions as dist
+import torch
+import numpy as np
+import scipy.sparse as sp
+
+import cellbender.remove_background.consts as consts
+
+from typing import Tuple, List, Dict, Optional
+from abc import ABC, abstractmethod
+import logging
+
+
+class Posterior(ABC):
+    """Base class Posterior handles posterior count inference.
+
+    Args:
+        dataset_obj: Dataset object.
+        vi_model: Trained RemoveBackgroundPyroModel.
+        counts_dtype: Data type of posterior count matrix.  Can be one of
+            [np.uint32, np.float]
+        float_threshold: For floating point count matrices, counts below
+            this threshold will be set to zero, for the purposes of constructing
+            a sparse matrix.  Unused if counts_dtype is np.uint32
+
+    Properties:
+        mean: Posterior count mean, as a sparse matrix.
+
+    """
+
+    def __init__(self,
+                 dataset_obj: 'SingleCellRNACountsDataset',  # Dataset
+                 vi_model: 'RemoveBackgroundPyroModel',
+                 counts_dtype: np.dtype = np.uint32,
+                 float_threshold: float = 0.5):
+        self.dataset_obj = dataset_obj
+        self.vi_model = vi_model
+        self.use_cuda = vi_model.use_cuda
+        self.analyzed_gene_inds = dataset_obj.analyzed_gene_inds
+        self.count_matrix_shape = dataset_obj.data['matrix'].shape
+        self.barcode_inds = np.arange(0, self.count_matrix_shape[0])
+        self.dtype = counts_dtype
+        self.float_threshold = float_threshold
+        self._mean = None
+        self._latents = None
+        super(Posterior, self).__init__()
+
+    @abstractmethod
+    def _get_mean(self):
+        """Obtain mean posterior counts and store in self._mean"""
+        pass
+
+    @property
+    def mean(self) -> sp.csc_matrix:
+        if self._mean is None:
+            self._get_mean()
+        return self._mean
+
+    @property
+    def latents(self) -> sp.csc_matrix:
+        if self._latents is None:
+            self._get_latents()
+        return self._latents
+
+    @property
+    def variance(self):
+        raise NotImplemented("Posterior count variance not implemented.")
+
+    @torch.no_grad()
+    def _get_latents(self):
+        """Calculate the encoded latent variables."""
+
+        data_loader = self.dataset_obj.get_dataloader(use_cuda=self.use_cuda,
+                                                      analyzed_bcs_only=True,
+                                                      batch_size=500,
+                                                      shuffle=False)
+
+        z = np.zeros((len(data_loader), self.vi_model.encoder['z'].output_dim))
+        d = np.zeros(len(data_loader))
+        p = np.zeros(len(data_loader))
+        epsilon = np.zeros(len(data_loader))
+
+        for i, data in enumerate(data_loader):
+
+            if 'chi_ambient' in pyro.get_param_store().keys():
+                chi_ambient = pyro.param('chi_ambient').detach()
+            else:
+                chi_ambient = None
+
+            enc = self.vi_model.encoder.forward(x=data, chi_ambient=chi_ambient)
+            ind = i * data_loader.batch_size
+            z[ind:(ind + data.shape[0]), :] = enc['z']['loc'].detach().cpu().numpy()
+
+            phi_loc = pyro.param('phi_loc')
+            phi_scale = pyro.param('phi_scale')
+
+            d[ind:(ind + data.shape[0])] = \
+                dist.LogNormal(loc=enc['d_loc'],
+                               scale=pyro.param('d_cell_scale')).mean.detach().cpu().numpy()
+
+            p[ind:(ind + data.shape[0])] = enc['p_y'].sigmoid().detach().cpu().numpy()
+
+            epsilon[ind:(ind + data.shape[0])] = dist.Gamma(enc['epsilon'] * self.vi_model.epsilon_prior,
+                                                            self.vi_model.epsilon_prior).mean.detach().cpu().numpy()
+
+        self._latents = {'z': z, 'd': d, 'p': p,
+                         'phi_loc_scale': [phi_loc.item(), phi_scale.item()],
+                         'epsilon': epsilon}
+
+    @torch.no_grad()
+    def _param_map_estimates(self,
+                             data: torch.Tensor,
+                             chi_ambient: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Calculate MAP estimates of mu, the mean of the true count matrix, and
+        lambda, the rate parameter of the Poisson background counts.
+
+        Args:
+            data: Dense tensor minibatch of cell by gene count data.
+            chi_ambient: Point estimate of inferred ambient gene expression.
+
+        Returns:
+            mu_map: Dense tensor of Negative Binomial means for true counts.
+            lambda_map: Dense tensor of Poisson rate params for noise counts.
+            alpha_map: Dense tensor of Dirichlet concentration params that
+                inform the overdispersion of the Negative Binomial.
+
+        """
+
+        # Encode latents.
+        enc = self.vi_model.encoder.forward(x=data,
+                                            chi_ambient=chi_ambient)
+        z_map = enc['z']['loc']
+
+        chi_map = self.vi_model.decoder.forward(z_map)
+        phi_loc = pyro.param('phi_loc')
+        phi_scale = pyro.param('phi_scale')
+        phi_conc = phi_loc.pow(2) / phi_scale.pow(2)
+        phi_rate = phi_loc / phi_scale.pow(2)
+        alpha_map = 1. / dist.Gamma(phi_conc, phi_rate).mean
+
+        y = (enc['p_y'] > 0).float()
+        d_empty = dist.LogNormal(loc=pyro.param('d_empty_loc'),
+                                 scale=pyro.param('d_empty_scale')).mean
+        d_cell = dist.LogNormal(loc=enc['d_loc'],
+                                scale=pyro.param('d_cell_scale')).mean
+        epsilon = dist.Gamma(enc['epsilon'] * self.vi_model.epsilon_prior,
+                             self.vi_model.epsilon_prior).mean
+
+        if self.vi_model.include_rho:
+            rho = pyro.param("rho_alpha") / (pyro.param("rho_alpha")
+                                             + pyro.param("rho_beta"))
+        else:
+            rho = None
+
+        # Calculate MAP estimates of mu and lambda.
+        mu_map = self.vi_model.calculate_mu(epsilon=epsilon,
+                                            d_cell=d_cell,
+                                            chi=chi_map,
+                                            y=y,
+                                            rho=rho)
+        lambda_map = self.vi_model.calculate_lambda(epsilon=epsilon,
+                                                    chi_ambient=chi_ambient,
+                                                    d_empty=d_empty,
+                                                    y=y,
+                                                    d_cell=d_cell,
+                                                    rho=rho,
+                                                    chi_bar=self.vi_model.avg_gene_expression)
+
+        return {'mu': mu_map, 'lam': lambda_map, 'alpha': alpha_map}
+
+    def dense_to_sparse(self,
+                        chunk_dense_counts: np.ndarray) -> Tuple[List, List, List]:
+        """Distill a batch of dense counts into sparse format.
+        Barcode numbering is relative to the tensor passed in.
+        """
+
+        # TODO: speed up by keeping it a torch tensor as long as possible
+
+        if chunk_dense_counts.dtype != np.int32:
+
+            if self.dtype == np.uint32:
+
+                # Turn the floating point count estimates into integers.
+                decimal_values, _ = np.modf(chunk_dense_counts)  # Stuff after decimal.
+                roundoff_counts = np.random.binomial(1, p=decimal_values)  # Bernoulli.
+                chunk_dense_counts = np.floor(chunk_dense_counts).astype(dtype=int)
+                chunk_dense_counts += roundoff_counts
+
+            elif self.dtype == np.float32:
+
+                # Truncate counts at a threshold value.
+                chunk_dense_counts = (chunk_dense_counts *
+                                      (chunk_dense_counts > self.float_threshold))
+
+            else:
+                raise NotImplementedError(f"Count matrix dtype {self.dtype} is not "
+                                          f"supported.  Choose from [np.uint32, "
+                                          f"np.float32]")
+
+        # Find all the nonzero counts in this dense matrix chunk.
+        nonzero_barcode_inds_this_chunk, nonzero_genes_trimmed = \
+            np.nonzero(chunk_dense_counts)
+        nonzero_counts = \
+            chunk_dense_counts[nonzero_barcode_inds_this_chunk,
+                               nonzero_genes_trimmed].flatten(order='C')
+
+        # Get the original gene index from gene index in the trimmed dataset.
+        nonzero_genes = self.analyzed_gene_inds[nonzero_genes_trimmed]
+
+        return nonzero_barcode_inds_this_chunk, nonzero_genes, nonzero_counts
+
+
+class ImputedPosterior(Posterior):
+    """Posterior count inference using imputation to infer cell mean (d * chi).
+
+    Args:
+        dataset_obj: Dataset object.
+        vi_model: Trained RemoveBackgroundPyroModel.
+        guide: Variational posterior pyro guide function, optional.  Only
+            specify if the required guide function is not vi_model.guide.
+        encoder: Encoder that provides encodings of data.
+        counts_dtype: Data type of posterior count matrix.  Can be one of
+            [np.uint32, np.float]
+        float_threshold: For floating point count matrices, counts below
+            this threshold will be set to zero, for the purposes of constructing
+            a sparse matrix.  Unused if counts_dtype is np.uint32
+
+    Properties:
+        mean: Posterior count mean, as a sparse matrix.
+        encodings: Encoded latent variables, one per barcode in the dataset.
+
+    """
+
+    def __init__(self,
+                 dataset_obj: 'SingleCellRNACountsDataset',  # Dataset
+                 vi_model: 'RemoveBackgroundPyroModel',  # Trained variational inference model
+                 guide=None,
+                 encoder=None,  #: Union[CompositeEncoder, None] = None,
+                 counts_dtype: np.dtype = np.uint32,
+                 float_threshold: float = 0.5):
+        self.vi_model = vi_model
+        self.use_cuda = vi_model.use_cuda
+        self.guide = guide if guide is not None else vi_model.encoder
+        self.encoder = encoder if encoder is not None else vi_model.encoder
+        self._encodings = None
+        self._mean = None
+        super(ImputedPosterior, self).__init__(dataset_obj=dataset_obj,
+                                               vi_model=vi_model,
+                                               counts_dtype=counts_dtype,
+                                               float_threshold=float_threshold)
+
+    @torch.no_grad()
+    def _get_mean(self):
+        """Send dataset through a guide that returns mean posterior counts.
+
+        Keep track of only what is necessary to distill a sparse count matrix.
+
+        """
+
+        data_loader = self.dataset_obj.get_dataloader(use_cuda=self.use_cuda,
+                                                      analyzed_bcs_only=False,
+                                                      batch_size=500,
+                                                      shuffle=False)
+
+        barcodes = []
+        genes = []
+        counts = []
+        ind = 0
+
+        for data in data_loader:
+
+            # Get return values from guide.
+            dense_counts_torch = self._param_map_estimates(data=data,
+                                                           chi_ambient=pyro.param("chi_ambient"))
+            dense_counts = dense_counts_torch.detach().cpu().numpy()
+            bcs_i_chunk, genes_i, counts_i = self.dense_to_sparse(dense_counts)
+
+            # Translate chunk barcode inds to overall inds.
+            bcs_i = self.barcode_inds[bcs_i_chunk + ind]
+
+            # Add sparse matrix values to lists.
+            barcodes.append(bcs_i)
+            genes.append(genes_i)
+            counts.append(counts_i)
+
+            # Increment barcode index counter.
+            ind += data.shape[0]  # Same as data_loader.batch_size
+
+        # Convert the lists to numpy arrays.
+        counts = np.array(np.concatenate(tuple(counts)), dtype=self.dtype)
+        barcodes = np.array(np.concatenate(tuple(barcodes)), dtype=np.uint32)
+        genes = np.array(np.concatenate(tuple(genes)), dtype=np.uint32)
+
+        # Put the counts into a sparse csc_matrix.
+        self._mean = sp.csc_matrix((counts, (barcodes, genes)),
+                                   shape=self.count_matrix_shape)
+
+
+class ProbPosterior(Posterior):
+    """Posterior count inference using a noise count probability distribution.
+
+    Args:
+        dataset_obj: Dataset object.
+        vi_model: Trained model: RemoveBackgroundPyroModel
+        fpr: Desired false positive rate for construction of the final regularized
+            posterior on true counts. False positives are true counts that are
+            (incorrectly) removed from the dataset.
+        float_threshold: For floating point count matrices, counts below
+            this threshold will be set to zero, for the purposes of constructing
+            a sparse matrix.  Unused if counts_dtype is np.uint32
+
+    Properties:
+        mean: Posterior count mean, as a sparse matrix.
+        encodings: Encoded latent variables, one per barcode in the dataset.
+
+    """
+
+    def __init__(self,
+                 dataset_obj: 'SingleCellRNACountsDataset',
+                 vi_model: 'RemoveBackgroundPyroModel',
+                 fpr: float = 0.01,
+                 float_threshold: float = 0.5):
+        self.vi_model = vi_model
+        self.use_cuda = vi_model.use_cuda
+        self.fpr = fpr
+        self.lambda_multiplier = None
+        self._encodings = None
+        self._mean = None
+        self.random = np.random.RandomState(seed=1234)
+        super(ProbPosterior, self).__init__(dataset_obj=dataset_obj,
+                                            vi_model=vi_model,
+                                            counts_dtype=np.uint32,
+                                            float_threshold=float_threshold)
+
+    @torch.no_grad()
+    def _get_mean(self):
+        """Send dataset through a guide that returns mean posterior counts.
+
+        Keep track of only what is necessary to distill a sparse count matrix.
+
+        """
+
+        # Get a dataset of ten cells.
+        cell_inds = np.where(self.latents['p'] > 0.9)[0]
+        lambda_mults = np.zeros(5)
+
+        for i in range(lambda_mults.size):
+
+            n_cells = min(consts.CELLS_POSTERIOR_REG_CALC, cell_inds.size)
+            if n_cells == 0:
+                raise ValueError('No cells found!  Cannot compute expected FPR.')
+            cell_ind_subset = self.random.choice(cell_inds, size=n_cells, replace=False)
+            cell_data = (torch.tensor(np.array(self.dataset_obj.get_count_matrix()
+                                               [cell_ind_subset, :].todense()).squeeze())
+                         .float().to(self.vi_model.device))
+
+            # Get the latents mu, alpha, and lambda for those cells.
+            chi_ambient = pyro.param("chi_ambient")
+            map_est = self._param_map_estimates(data=cell_data, chi_ambient=chi_ambient)
+
+            # Find the optimal lambda_multiplier value using those cells and target FPR.
+            lambda_mult = self._lambda_binary_search_given_fpr(cell_data=cell_data,
+                                                               fpr=self.fpr,
+                                                               mu_est=map_est['mu'],
+                                                               lambda_est=map_est['lam'],
+                                                               alpha_est=map_est['alpha'])
+            lambda_mults[i] = lambda_mult
+
+        optimal_lambda_mult = np.mean(lambda_mults)
+        self.lambda_multiplier = optimal_lambda_mult
+        logging.info(f'Optimal posterior regularization factor = {optimal_lambda_mult:.2f}')
+
+        # Compute posterior in mini-batches.
+        analyzed_bcs_only = True
+        data_loader = self.dataset_obj.get_dataloader(use_cuda=self.use_cuda,
+                                                      analyzed_bcs_only=analyzed_bcs_only,
+                                                      batch_size=20,
+                                                      shuffle=False)
+        barcodes = []
+        genes = []
+        counts = []
+        ind = 0
+
+        for data in data_loader:
+
+            # Compute an estimate of the true counts.
+            dense_counts = self._compute_true_counts(data=data,
+                                                     chi_ambient=chi_ambient,
+                                                     lambda_multiplier=optimal_lambda_mult,
+                                                     use_map=False,
+                                                     n_samples=9)  # must be odd number
+            bcs_i_chunk, genes_i, counts_i = self.dense_to_sparse(dense_counts)
+
+            # Translate chunk barcode inds to overall inds.
+            if analyzed_bcs_only:
+                bcs_i = self.dataset_obj.analyzed_barcode_inds[bcs_i_chunk + ind]
+            else:
+                bcs_i = self.barcode_inds[bcs_i_chunk + ind]
+
+            # Add sparse matrix values to lists.
+            barcodes.append(bcs_i)
+            genes.append(genes_i)
+            counts.append(counts_i)
+
+            # Increment barcode index counter.
+            ind += data.shape[0]  # Same as data_loader.batch_size
+
+        # Convert the lists to numpy arrays.
+        counts = np.array(np.concatenate(tuple(counts)), dtype=self.dtype)
+        barcodes = np.array(np.concatenate(tuple(barcodes)), dtype=np.uint32)
+        genes = np.array(np.concatenate(tuple(genes)), dtype=np.uint32)  # uint16 is too small!
+
+        # Put the counts into a sparse csc_matrix.
+        self._mean = sp.csc_matrix((counts, (barcodes, genes)),
+                                   shape=self.count_matrix_shape)
+
+    @torch.no_grad()
+    def _compute_true_counts(self,
+                             data: torch.Tensor,
+                             chi_ambient: torch.Tensor,
+                             lambda_multiplier: float,
+                             use_map: bool = True,
+                             n_samples: int = 1) -> np.ndarray:
+        """Compute the true de-noised count matrix for this minibatch.
+
+        Can use either a MAP estimate of lambda and mu, or can use a sampling
+        approach.
+
+        Args:
+            data: Dense tensor minibatch of cell by gene count data.
+            chi_ambient: Point estimate of inferred ambient gene expression.
+            lambda_multiplier: Value by which lambda gets multiplied in order
+                to compute regularized posterior true counts.
+            use_map: True to use a MAP estimate of lambda and mu.
+            n_samples: If not using a MAP estimate, this specifies the number
+                of samples to use in calculating the posterior mean.
+
+        Returns:
+            dense_counts: Dense matrix of true de-noised counts.
+
+        """
+
+        if use_map:
+
+            # Calculate MAP estimates of mu and lambda.
+            est = self._param_map_estimates(data, chi_ambient)
+            mu_map = est['mu']
+            lambda_map = est['lam']
+            alpha_map = est['alpha']
+
+            # Compute the de-noised count matrix given the MAP estimates.
+            dense_counts_torch = self._true_counts_from_params(data,
+                                                               mu_map,
+                                                               lambda_map * lambda_multiplier + 1e-30,
+                                                               alpha_map + 1e-30)
+
+            dense_counts = dense_counts_torch.detach().cpu().numpy()
+
+        else:
+
+            assert n_samples > 0, f"Posterior mean estimate needs to be derived " \
+                                  f"from at least one sample: here {n_samples} " \
+                                  f"samples are called for."
+
+            dense_counts_torch = torch.zeros((data.shape[0],
+                                              data.shape[1],
+                                              n_samples),
+                                             dtype=torch.float32).to(data.device)
+
+            for i in range(n_samples):
+
+                # Sample from mu and lambda.
+                mu_sample, lambda_sample, alpha_sample = \
+                    self._param_sample(data)
+
+                # Compute the de-noised count matrix given the estimates.
+                dense_counts_torch[..., i] = \
+                    self._true_counts_from_params(data,
+                                                  mu_sample,
+                                                  lambda_sample * lambda_multiplier + 1e-30,
+                                                  alpha_sample + 1e-30)
+
+            # Take the median of the posterior true count distribution... torch cuda does not implement mode
+            dense_counts = dense_counts_torch.median(dim=2, keepdim=False)[0]
+            dense_counts = dense_counts.detach().cpu().numpy().astype(np.int32)
+
+        return dense_counts
+
+    @torch.no_grad()
+    def _param_sample(self,
+                      data: torch.Tensor) -> Tuple[torch.Tensor,
+                                                   torch.Tensor,
+                                                   torch.Tensor]:
+        """Calculate a single sample estimate of mu, the mean of the true count
+        matrix, and lambda, the rate parameter of the Poisson background counts.
+
+        Args:
+            data: Dense tensor minibatch of cell by gene count data.
+
+        Returns:
+            mu_sample: Dense tensor sample of Negative Binomial mean for true
+                counts.
+            lambda_sample: Dense tensor sample of Poisson rate params for noise
+                counts.
+            alpha_sample: Dense tensor sample of Dirichlet concentration params
+                that inform the overdispersion of the Negative Binomial.
+
+        """
+
+        # Use pyro poutine to trace the guide and sample parameter values.
+        guide_trace = pyro.poutine.trace(self.vi_model.guide).get_trace(x=data)
+        replayed_model = pyro.poutine.replay(self.vi_model.model, guide_trace)
+
+        # Run the model using these sampled values.
+        replayed_model_output = replayed_model(x=data)
+
+        # The model returns mu, alpha, and lambda.
+        mu_sample = replayed_model_output['mu']
+        lambda_sample = replayed_model_output['lam']
+        alpha_sample = replayed_model_output['alpha']
+
+        return mu_sample, lambda_sample, alpha_sample
+
+    @torch.no_grad()
+    def _true_counts_from_params(self,
+                                 data: torch.Tensor,
+                                 mu_est: torch.Tensor,
+                                 lambda_est: torch.Tensor,
+                                 alpha_est: torch.Tensor) -> torch.Tensor:
+        """Calculate a single sample estimate of mu, the mean of the true count
+        matrix, and lambda, the rate parameter of the Poisson background counts.
+
+        Args:
+            data: Dense tensor minibatch of cell by gene count data.
+            mu_est: Dense tensor of Negative Binomial means for true counts.
+            lambda_est: Dense tensor of Poisson rate params for noise counts.
+            alpha_est: Dense tensor of Dirichlet concentration params that
+                inform the overdispersion of the Negative Binomial.
+
+        Returns:
+            dense_counts_torch: Dense matrix of true de-noised counts.
+
+        """
+
+        # Estimate a reasonable low-end to begin the Poisson summation.
+        n = min(100., data.max().item())  # No need to exceed the max value
+        poisson_values_low = (lambda_est.detach() - n / 2).int()
+
+        poisson_values_low = torch.clamp(torch.min(poisson_values_low,
+                                                   (data - n + 1).int()), min=0).float()
+
+        # Construct a big tensor of possible noise counts per cell per gene,
+        # shape (batch_cells, n_genes, max_noise_counts)
+        noise_count_tensor = torch.arange(start=0, end=n) \
+            .expand([data.shape[0], data.shape[1], -1]) \
+            .float().to(device=data.device)
+        noise_count_tensor = noise_count_tensor + poisson_values_low.unsqueeze(-1)
+
+        # Compute probabilities of each number of noise counts.
+        # NOTE: some values will be outside the support (negative values for NB).
+        # The resulting NaNs are ignored by torch.argmax().
+        logits = (mu_est.log() - alpha_est.log()).unsqueeze(-1)
+        log_prob_tensor = (dist.Poisson(lambda_est.unsqueeze(-1))
+                           .log_prob(noise_count_tensor)
+                           + dist.NegativeBinomial(total_count=alpha_est.unsqueeze(-1),
+                                                   logits=logits)
+                           .log_prob(data.unsqueeze(-1) - noise_count_tensor))
+        log_prob_tensor = torch.where(noise_count_tensor <= data.unsqueeze(-1),
+                                      log_prob_tensor,
+                                      torch.ones_like(log_prob_tensor) * -np.inf)
+
+        # Find the most probable number of noise counts per cell per gene.
+        noise_count_map = torch.argmax(log_prob_tensor,
+                                       dim=-1,
+                                       keepdim=False).float()
+
+        # Handle the cases where y = 0 (no cell): all counts are noise.
+        noise_count_map = torch.where(mu_est == 0,
+                                      data,
+                                      noise_count_map)
+
+        # Compute the number of true counts.
+        dense_counts_torch = torch.clamp(data - noise_count_map, min=0.)
+
+        return dense_counts_torch
+
+    @torch.no_grad()
+    def _calculate_expected_fpr_from_map(self,
+                                         data: torch.Tensor,
+                                         data_map: torch.Tensor) -> torch.Tensor:
+        """Given inferred latent variables and observed total counts,
+        generate a MAP estimate for noise counts.  Use that MAP estimate to
+        compute the expected false positive rate.
+
+        Args:
+            data: Dense tensor tiny minibatch of cell by gene count data.
+            data_map: Dense tensor tiny minibatch of MAP output for that data.
+
+        Returns:
+            fpr: Expected false positive rate.
+
+        """
+
+        counts_per_cell = data.sum(dim=-1)
+        map_counts_per_cell = data_map.sum(dim=-1)
+        fraction_counts_removed_per_cell = (counts_per_cell - map_counts_per_cell) / counts_per_cell
+        empty_droplet_mean_counts = dist.LogNormal(loc=pyro.param('d_empty_loc'),
+                                                   scale=pyro.param('d_empty_scale')).mean
+        ambient_fraction = empty_droplet_mean_counts / counts_per_cell
+        if self.vi_model.include_rho:
+            swapping_fraction = dist.Beta(pyro.param('rho_alpha'), pyro.param('rho_beta')).mean
+        else:
+            swapping_fraction = 0.
+
+        mean_cell_epsilon = (self.latents['epsilon'][self.latents['p'] > 0.5]).mean()
+        target_fraction_counts_removed_per_cell = (ambient_fraction
+                                                   + swapping_fraction) / mean_cell_epsilon
+        fpr_expectation = (fraction_counts_removed_per_cell - target_fraction_counts_removed_per_cell).mean()
+
+        fpr_expectation = torch.clamp(fpr_expectation, min=0.)
+
+        return fpr_expectation.mean()
+
+    @torch.no_grad()
+    def _calculate_expected_fpr_given_lambda_mult(self,
+                                                  data: torch.Tensor,
+                                                  lambda_mult: float,
+                                                  mu_est: torch.Tensor,
+                                                  alpha_est: torch.Tensor,
+                                                  lambda_est: torch.Tensor) -> torch.Tensor:
+        """Given a float lambda_mult, calculate a MAP estimate of output counts,
+        and use that estimate to calculate an expected false positive rate.
+
+        Args:
+            data: Dense tensor tiny minibatch of cell by gene count data.
+            lambda_mult: Value of the lambda multiplier.
+            mu_est: Dense tensor of Negative Binomial means for true counts.
+            lambda_est: Dense tensor of Poisson rate params for noise counts.
+            alpha_est: Dense tensor of Dirichlet concentration params that
+                inform the overdispersion of the Negative Binomial.
+
+        Returns:
+            fpr: Expected false positive rate.
+
+        """
+
+        # Compute MAP estimate of true de-noised counts.
+        data_map = self._true_counts_from_params(data=data,
+                                                 mu_est=mu_est,
+                                                 lambda_est=lambda_est * lambda_mult,
+                                                 alpha_est=alpha_est)
+
+        # Compute expected false positive rate.
+        expected_fpr = self._calculate_expected_fpr_from_map(data=data,
+                                                             data_map=data_map)
+
+        return expected_fpr
+
+    @torch.no_grad()
+    def _lambda_binary_search_given_fpr(self,
+                                        cell_data: torch.Tensor,
+                                        fpr: float,
+                                        mu_est: torch.Tensor,
+                                        lambda_est: torch.Tensor,
+                                        alpha_est: torch.Tensor,
+                                        lam_mult_init: float = 1.,
+                                        fpr_tolerance: Optional[float] = None,
+                                        max_iterations: int = consts.POSTERIOR_REG_SEARCH_MAX_ITER) -> float:
+        """Perform a binary search for the appropriate lambda-multiplier which will
+        achieve a desired false positive rate.
+
+        NOTE: It is assumed that
+        expected_fpr(lam_mult_bracket[0]) < fpr < expected_fpr(lam_mult_bracket[1]).
+        If this is not the case, the algorithm will produce an output close to one
+        of the brackets, and FPR control will not be achieved.
+
+        Args:
+            cell_data: Data from a fraction of the total number of cells.
+            fpr: Desired false positive rate.
+            mu_est: Dense tensor of Negative Binomial means for true counts.
+            lambda_est: Dense tensor of Poisson rate params for noise counts.
+            alpha_est: Dense tensor of Dirichlet concentration params that
+                inform the overdispersion of the Negative Binomial.
+            lam_mult_init: Initial value of the lambda multiplier, hopefully
+                close to the unknown target value.
+            fpr_tolerance: Tolerated error in expected false positive rate.  If
+                input is None, defaults to 0.001 or fpr / 10, whichever is
+                smaller.
+            max_iterations: A cutoff to ensure termination. Even if a tolerable
+                solution is not found, the algorithm will stop after this many
+                iterations and return the best answer so far.
+
+        Returns:
+            lam_mult: Value of the lambda-multiplier.
+
+        """
+
+        assert (fpr > 0) and (fpr < 1), "Target FPR should be in the interval (0, 1)."
+        if fpr_tolerance is None:
+            fpr_tolerance = min(fpr / 10., 0.001)
+
+        # Begin at initial value.
+        lam_mult = lam_mult_init
+
+        # Calculate an expected false positive rate for this lam_mult value.
+        expected_fpr = self._calculate_expected_fpr_given_lambda_mult(
+            data=cell_data,
+            lambda_mult=lam_mult,
+            mu_est=mu_est,
+            lambda_est=lambda_est,
+            alpha_est=alpha_est)
+
+        # Find out what direction we need to move in.
+        residual = fpr - expected_fpr
+        initial_residual_sign = residual.sign()  # plus or minus one
+        if initial_residual_sign.item() == 0:
+            # In the unlikely event that we hit the value exactly.
+            return lam_mult
+
+        # Travel in one direction until the direction of FPR error changes.
+        lam_limit = lam_mult_init
+        i = 0
+        while ((lam_limit < consts.POSTERIOR_REG_MAX)
+               and (lam_limit > consts.POSTERIOR_REG_MIN)
+               and (residual.sign() == initial_residual_sign)
+               and (i < max_iterations)):
+
+            lam_limit = lam_limit * (initial_residual_sign * 2).exp().item()
+
+            # Calculate an expected false positive rate for this lam_mult value.
+            expected_fpr = self._calculate_expected_fpr_given_lambda_mult(
+                data=cell_data,
+                lambda_mult=lam_limit,
+                mu_est=mu_est,
+                lambda_est=lambda_est,
+                alpha_est=alpha_est)
+
+            residual = fpr - expected_fpr
+            i = i + 1  # one dataset had this go into an infinite loop, taking lam_limit -> 0
+
+        # Define the values that bracket the correct answer.
+        lam_mult_bracket = np.sort(np.array([lam_mult_init, lam_limit]))
+
+        # Binary search algorithm.
+        for i in range(max_iterations):
+
+            # Current test value for the lambda-multiplier.
+            lam_mult = np.mean(lam_mult_bracket)
+
+            # Calculate an expected false positive rate for this lam_mult value.
+            expected_fpr = self._calculate_expected_fpr_given_lambda_mult(
+                data=cell_data,
+                lambda_mult=lam_mult,
+                mu_est=mu_est,
+                lambda_est=lambda_est,
+                alpha_est=alpha_est)
+
+            # Check on false positive rate and update our bracket values.
+            if (expected_fpr < (fpr + fpr_tolerance)) and (expected_fpr > (fpr - fpr_tolerance)):
+                break
+            elif expected_fpr > fpr:
+                lam_mult_bracket[1] = lam_mult
+            elif expected_fpr < fpr:
+                lam_mult_bracket[0] = lam_mult
+
+        # If we stopped due to iteration limit, take the average lam_mult value.
+        if i == max_iterations:
+            lam_mult = np.mean(lam_mult_bracket)
+
+        # Check to see if we have achieved the desired FPR control.
+        if not ((expected_fpr < (fpr + fpr_tolerance)) and (expected_fpr > (fpr - fpr_tolerance))):
+            print(f'FPR control not achieved in {max_iterations} attempts. '
+                  f'Output FPR is esitmated to be {expected_fpr.item():.4f}')
+
+        return lam_mult

--- a/cellbender/remove_background/model.py
+++ b/cellbender/remove_background/model.py
@@ -1,19 +1,27 @@
 """Definition of the model and the inference setup, with helper functions."""
 
 import numpy as np
-import scipy.sparse as sp
+
 import torch
 import torch.nn as nn
 from torch.distributions import constraints
+
 import pyro
 import pyro.distributions as dist
 from pyro.infer import config_enumerate
+import pyro.poutine as poutine
+
 from cellbender.remove_background.vae import encoder as encoder_module
 import cellbender.remove_background.consts as consts
+from cellbender.remove_background.distributions.NegativeBinomialPoissonConv \
+    import NegativeBinomialPoissonConv as NBPC
+from cellbender.remove_background.distributions.NegativeBinomialPoissonConvApprox \
+    import NegativeBinomialPoissonConvApprox as NBPCapprox
+from cellbender.remove_background.distributions.NullDist import NullDist
+from cellbender.remove_background.exceptions import NanException
 
-from typing import Union, Tuple
+from typing import Optional, Union
 from numbers import Number
-import logging
 
 
 class RemoveBackgroundPyroModel(nn.Module):
@@ -25,21 +33,18 @@ class RemoveBackgroundPyroModel(nn.Module):
         encoder: An instance of an encoder object.  Can be a CompositeEncoder.
         decoder: An instance of a decoder object.
         dataset_obj: Dataset object which contains relevant priors.
-        phi_loc_prior: Location parameter for the prior of a Gamma distribution
-            for the overdispersion, Phi, of the negative binomial distribution
-            used for sampling counts.
-        phi_scale_prior: Location parameter for the prior of a Gamma
-            distribution for the overdispersion, Phi, of the negative binomial
-            distribution used for sampling counts.
-        rho_alpha_prior: Alpha parameter for Beta distribution of the
-            contamination parameter, rho.
-        rho_beta_prior: Beta parameter for Beta distribution of the
-            contamination parameter, rho.
         use_cuda: Will use GPU if True.
+        phi_loc_prior: Mean of gamma distribution for global overdispersion.
+        phi_scale_prior: Scale of gamma distribution for global overdispersion.
+        rho_alpha_prior: Param of beta distribution for swapping fraction.
+        rho_beta_prior: Param of beta distribution for swapping fraction.
+        use_exact_log_prob: False (typical usage) to use an approximate log_prob
+            computation, which is faster than an exact calculation.
 
     Attributes:
         All the above, plus
         device: Either 'cpu' or 'cuda' depending on value of use_cuda.
+        loss: Dict that records information about the loss during training.
 
     """
 
@@ -48,11 +53,12 @@ class RemoveBackgroundPyroModel(nn.Module):
                  encoder: Union[nn.Module, encoder_module.CompositeEncoder],
                  decoder: nn.Module,
                  dataset_obj: 'SingleCellRNACountsDataset',
-                 phi_loc_prior: float = 0.2,
-                 phi_scale_prior: float = 0.2,
-                 rho_alpha_prior: float = 3,
-                 rho_beta_prior: float = 80,
-                 use_cuda: bool = False):
+                 use_cuda: bool,
+                 phi_loc_prior: float = consts.PHI_LOC_PRIOR,
+                 phi_scale_prior: float = consts.PHI_SCALE_PRIOR,
+                 rho_alpha_prior: float = consts.RHO_ALPHA_PRIOR,
+                 rho_beta_prior: float = consts.RHO_BETA_PRIOR,
+                 use_exact_log_prob: bool = consts.USE_EXACT_LOG_PROB):
         super(RemoveBackgroundPyroModel, self).__init__()
 
         self.model_type = model_type
@@ -67,6 +73,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         self.z_dim = decoder.input_dim
         self.encoder = encoder
         self.decoder = decoder
+        self.use_exact_log_prob = use_exact_log_prob
         self.loss = {'train': {'epoch': [], 'elbo': []},
                      'test': {'epoch': [], 'elbo': []}}
 
@@ -93,53 +100,14 @@ class RemoveBackgroundPyroModel(nn.Module):
             f"Issue with prior: cell_counts is " \
             f"{dataset_obj.priors['cell_counts']}, but should be > 0."
 
-        self.d_cell_loc_prior = (np.log1p(dataset_obj.priors['cell_counts'],
-                                          dtype=np.float32).item()
-                                 * torch.ones(torch.Size([])).to(self.device))
-        self.d_cell_scale_prior = (np.array(dataset_obj.priors['d_std'],
-                                            dtype=np.float32).item()
-                                   * torch.ones(torch.Size([])).to(self.device))
+        self.d_cell_loc_prior = torch.tensor(np.log1p(dataset_obj.priors['cell_counts']))\
+            .float().to(self.device)
+
+        self.d_cell_scale_prior = (torch.tensor(consts.D_STD_PRIOR).to(self.device))
         self.z_loc_prior = torch.zeros(torch.Size([self.z_dim])).to(self.device)
         self.z_scale_prior = torch.ones(torch.Size([self.z_dim]))\
             .to(self.device)
-
-        if self.model_type != "simple":
-
-            assert dataset_obj.priors['empty_counts'] > 0, \
-                f"Issue with prior: empty_counts should be > 0, but is " \
-                f"{dataset_obj.priors['empty_counts']}"
-            chi_ambient_sum = np.round(dataset_obj.priors['chi_ambient']
-                                       .sum().item(),
-                                       decimals=4).item()
-            assert chi_ambient_sum == 1., f"Issue with prior: chi_ambient " \
-                                          f"should sum to 1, but it sums to " \
-                                          f"{chi_ambient_sum}"
-            chi_bar_sum = np.round(dataset_obj.priors['chi_bar'].sum().item(),
-                                       decimals=4)
-            assert chi_bar_sum == 1., f"Issue with prior: chi_bar should " \
-                                      f"sum to 1, but is {chi_bar_sum}"
-
-            self.d_empty_loc_prior = (np.log1p(dataset_obj
-                                               .priors['empty_counts'],
-                                               dtype=np.float32).item()
-                                      * torch.ones(torch.Size([]))
-                                      .to(self.device))
-            self.d_empty_scale_prior = (np.array(dataset_obj.priors['d_std'],
-                                                 dtype=np.float32).item()
-                                        * torch.ones(torch.Size([]))
-                                        .to(self.device))
-
-            self.p_logit_prior = (dataset_obj.priors['cell_logit']
-                                  * torch.ones(torch.Size([])).to(self.device))
-
-            self.chi_ambient_init = dataset_obj.priors['chi_ambient']\
-                .to(self.device)
-            self.avg_gene_expression = dataset_obj.priors['chi_bar']\
-                .to(self.device)
-
-        else:
-
-            self.avg_gene_expression = None
+        self.epsilon_prior = torch.tensor(consts.EPSILON_PRIOR).to(self.device)
 
         self.phi_loc_prior = (phi_loc_prior
                               * torch.ones(torch.Size([])).to(self.device))
@@ -150,104 +118,99 @@ class RemoveBackgroundPyroModel(nn.Module):
         self.phi_rate_prior = ((phi_loc_prior / phi_scale_prior ** 2)
                                * torch.ones(torch.Size([])).to(self.device))
 
+        if self.model_type != "simple":
+
+            assert dataset_obj.priors['empty_counts'] > 0, \
+                f"Issue with prior: empty_counts should be > 0, but is " \
+                f"{dataset_obj.priors['empty_counts']}"
+            chi_ambient_sum = dataset_obj.priors['chi_ambient'].sum()
+            assert np.isclose(a=chi_ambient_sum, b=[1.], atol=1e-5), \
+                f"Issue with prior: chi_ambient should sum to 1, but it sums " \
+                f"to {chi_ambient_sum}"
+            chi_bar_sum = dataset_obj.priors['chi_bar'].sum()
+            assert np.isclose(a=chi_bar_sum, b=[1.], atol=1e-5), \
+                f"Issue with prior: chi_bar should sum to 1, but is {chi_bar_sum}"
+
+            self.d_empty_loc_prior = (np.log1p(dataset_obj
+                                               .priors['empty_counts'],
+                                               dtype=np.float32).item()
+                                      * torch.ones(torch.Size([]))
+                                      .to(self.device))
+
+            self.d_empty_scale_prior = (np.array(dataset_obj.priors['d_std'],
+                                                 dtype=np.float32).item()
+                                        * torch.ones(torch.Size([])).to(self.device))
+
+            self.p_logit_prior = (dataset_obj.priors['cell_logit']
+                                  * torch.ones(torch.Size([])).to(self.device))
+
+            self.chi_ambient_init = dataset_obj.priors['chi_ambient']\
+                .to(self.device)
+            self.avg_gene_expression = dataset_obj.priors['chi_bar'] \
+                .to(self.device)
+
+            self.empty_UMI_threshold = (torch.tensor(dataset_obj.empty_UMI_threshold)
+                                        .float().to(self.device))
+
+        else:
+
+            self.avg_gene_expression = None
+
         self.rho_alpha_prior = (rho_alpha_prior
                                 * torch.ones(torch.Size([])).to(self.device))
         self.rho_beta_prior = (rho_beta_prior
                                * torch.ones(torch.Size([])).to(self.device))
 
-    def _calculate_mu(self,
-                      chi: torch.Tensor,
-                      d_cell: torch.Tensor,
-                      chi_ambient: Union[torch.Tensor, None] = None,
-                      d_empty: Union[torch.Tensor, None] = None,
-                      y: Union[torch.Tensor, None] = None,
-                      rho: Union[torch.Tensor, None] = None,
-                      chi_bar: Union[torch.Tensor, None] = None):
-        """Implement a calculation of mean expression based on the model."""
+    def calculate_lambda(self,
+                         epsilon: torch.Tensor,
+                         chi_ambient: torch.Tensor,
+                         d_empty: torch.Tensor,
+                         y: Optional[torch.Tensor] = None,
+                         d_cell: Optional[torch.Tensor] = None,
+                         rho: Optional[torch.Tensor] = None,
+                         chi_bar: Optional[torch.Tensor] = None):
+        """Calculate noise rate based on the model."""
 
-        if self.model_type == "simple":
-            """The model is that a latent variable z is drawn from a z_dim 
-            dimensional normal distribution.  This latent z is put through the 
-            decoder to generate a full vector of fractional gene expression, 
-            chi.  Counts are then drawn from a negative binomial distribution 
-            with mean d * chi.  d is drawn from a LogNormal distribution with 
-            the specified prior.  Phi is the overdispersion of this negative 
-            binomial, and is drawn from a Gamma distribution with the specified 
-            prior.
-
-            """
-            mu = d_cell.unsqueeze(-1) * chi
-
-        elif self.model_type == "ambient":
-            """There is a global hyperparameter called chi_ambient.  This 
-            parameter
-            is the learned fractional gene expression vector for ambient RNA.
-            The model is that a latent variable z is drawn from a z_dim 
-            dimensional normal distribution.  This latent z is put through the 
-            decoder to generate a full vector of fractional gene expression, 
-            chi.  Counts are then drawn from a negative binomial distribution 
-            with mean d_cell * chi + d_ambient * chi_ambient.  d_cell is drawn 
-            from a LogNormal distribution with the specified prior, as is 
-            d_ambient.  Phi is the overdispersion of this negative binomial, 
-            and is drawn from a Gamma distribution with the specified prior.
-
-            """
-            mu = (y.unsqueeze(-1) * d_cell.unsqueeze(-1) * chi
-                  + d_empty.unsqueeze(-1) * chi_ambient.unsqueeze(0))
-
-        elif self.model_type == "full":
-            """There is a global hyperparameter called chi_ambient.  This 
-            parameter is the learned fractional gene expression vector for 
-            ambient RNA, which in this model could be a combination of 
-            cell-free RNA and the average of cellular RNA which has been 
-            erroneously barcode-swapped.  The model is that a latent variable 
-            z is drawn from a z_dim dimensional normal distribution.  This 
-            latent z is put through the decoder to generate a full vector of 
-            fractional gene expression, chi.  Counts are then drawn from a 
-            negative binomial distribution with mean
-            (1 - rho) * [y * d * chi + d_ambient * chi_ambient]
-            + rho * (y * d + d_ambient) * chi_average.  d is drawn from a
-            LogNormal distribution with the specified prior.  Phi is the
-            overdispersion of this negative binomial, and is drawn from a Gamma
-            distribution with the specified prior.  Rho is the contamination
-            fraction, or swapping / stealing fraction, i.e. the fraction of 
-            reads in the cell barcode that do not originate from that cell 
-            barcode's droplet.
-    
-            """
-            mu = ((1 - rho.unsqueeze(-1))
-                  * (y.unsqueeze(-1) * d_cell.unsqueeze(-1) * chi
-                     + d_empty.unsqueeze(-1) * chi_ambient.unsqueeze(0))
-                  + rho.unsqueeze(-1)
-                  * (y.unsqueeze(-1) * d_cell.unsqueeze(-1)
-                     + d_empty.unsqueeze(-1))
-                  * chi_bar)
+        if self.model_type == "simple" or self.model_type == "ambient":
+            lam = epsilon.unsqueeze(-1) * d_empty.unsqueeze(-1) * chi_ambient
 
         elif self.model_type == "swapping":
-            """The parameter chi_average is the average of cellular RNA which 
-            has been erroneously barcode-swapped or otherwise mis-assigned to 
-            another barcode.  The model is that a latent variable z is drawn 
-            from a z_dim dimensional normal distribution.  This latent z is put 
-            through the decoder to generate a full vector of fractional gene 
-            expression, chi.  Counts are then drawn from a negative binomial 
-            distribution with mean
-            (1 - rho) * [y * d * chi] + (rho * y * d + d_ambient) * chi_average.
-            d is drawn from a LogNormal distribution with the specified prior.
-            Phi is the overdispersion of this negative binomial, and is drawn 
-            from a Gamma distribution with the specified prior.  Rho is the 
-            contamination fraction, or swapping / stealing fraction, i.e. the 
-            fraction of reads in the cell barcode that do not originate from 
-            that cell barcode's droplet.
-    
-            """
-            mu = ((1 - rho.unsqueeze(-1))
-                  * (y.unsqueeze(-1) * d_cell.unsqueeze(-1) * chi)
-                  + (rho.unsqueeze(-1)
-                     * y.unsqueeze(-1) * d_cell.unsqueeze(-1)
-                     + d_empty.unsqueeze(-1)) * chi_bar)
+            lam = (rho.unsqueeze(-1) * chi_bar *
+                   (y.unsqueeze(-1) * d_cell.unsqueeze(-1) + d_empty.unsqueeze(-1)))
+
+        elif self.model_type == "full":
+            lam = (epsilon.unsqueeze(-1)
+                   * ((1. - rho.unsqueeze(-1)) * chi_ambient * d_empty.unsqueeze(-1)
+                   + rho.unsqueeze(-1) * chi_bar * (y.unsqueeze(-1) * d_cell.unsqueeze(-1)
+                                                    + d_empty.unsqueeze(-1))))
+        else:
+            raise ValueError(f"model_type was set to {self.model_type}, "
+                             f"which is not implemented.")
+
+        return lam
+
+    def calculate_mu(self,
+                     epsilon: torch.Tensor,
+                     d_cell: torch.Tensor,
+                     chi: torch.Tensor,
+                     y: Optional[torch.Tensor] = None,
+                     rho: Optional[torch.Tensor] = None):
+        """Calculate mean expression based on the model."""
+
+        if self.model_type == 'simple':
+            mu = epsilon.unsqueeze(-1) * d_cell.unsqueeze(-1) * chi
+
+        elif self.model_type == 'ambient':
+            mu = (y.unsqueeze(-1) * epsilon.unsqueeze(-1)
+                  * d_cell.unsqueeze(-1) * chi)
+
+        elif self.model_type == 'swapping' or self.model_type == 'full':
+            mu = ((1. - rho.unsqueeze(-1))
+                  * y.unsqueeze(-1) * epsilon.unsqueeze(-1)
+                  * d_cell.unsqueeze(-1) * chi)
 
         else:
-            raise NotImplementedError(f"model_type was set to {model_type}, "
+            raise NotImplementedError(f"model_type was set to {self.model_type}, "
                                       f"which is not implemented.")
 
         return mu
@@ -277,17 +240,14 @@ class RemoveBackgroundPyroModel(nn.Module):
                           dist.Gamma(self.phi_conc_prior,
                                      self.phi_rate_prior))
 
-        # Add L1 regularization term to the loss based on decoder weights.
-        # self._regularize(x.size(0))
-
         # Happens in parallel for each data point (cell barcode) independently:
         with pyro.plate("data", x.size(0),
                         use_cuda=self.use_cuda, device=self.device):
 
             # Sample z from prior.
             z = pyro.sample("z",
-                            dist.Normal(self.z_loc_prior,
-                                        self.z_scale_prior)
+                            dist.Normal(loc=self.z_loc_prior,
+                                        scale=self.z_scale_prior)
                             .expand_by([x.size(0)]).to_event(1))
 
             # Decode the latent code z to get fractional gene expression, chi.
@@ -295,8 +255,8 @@ class RemoveBackgroundPyroModel(nn.Module):
 
             # Sample d_cell based on priors.
             d_cell = pyro.sample("d_cell",
-                                 dist.LogNormal(self.d_cell_loc_prior,
-                                                self.d_cell_scale_prior)
+                                 dist.LogNormal(loc=self.d_cell_loc_prior,
+                                                scale=self.d_cell_scale_prior)
                                  .expand_by([x.size(0)]))
 
             # Sample swapping fraction rho.
@@ -307,43 +267,131 @@ class RemoveBackgroundPyroModel(nn.Module):
             else:
                 rho = None
 
+            # Sample epsilon based on priors.
+            epsilon = pyro.sample("epsilon",
+                                  dist.Gamma(concentration=self.epsilon_prior,
+                                             rate=self.epsilon_prior)
+                                  .expand_by([x.size(0)]))
+
             # If modelling empty droplets:
             if self.include_empties:
 
                 # Sample d_empty based on priors.
                 d_empty = pyro.sample("d_empty",
-                                      dist.LogNormal(self.d_empty_loc_prior,
-                                                     self.d_empty_scale_prior)
+                                      dist.LogNormal(loc=self.d_empty_loc_prior,
+                                                     scale=self.d_empty_scale_prior)
                                       .expand_by([x.size(0)]))
 
                 # Sample y, the presence of a real cell, based on p_logit_prior.
                 y = pyro.sample("y",
-                                dist.Bernoulli(logits=self.p_logit_prior)
+                                dist.Bernoulli(logits=self.p_logit_prior - 100.)  # TODO
                                 .expand_by([x.size(0)]))
+
             else:
                 d_empty = None
                 y = None
 
             # Calculate the mean gene expression counts (for each barcode).
-            mu = self._calculate_mu(chi, d_cell,
-                                    chi_ambient=chi_ambient,
-                                    d_empty=d_empty,
-                                    y=y,
-                                    rho=rho,
-                                    chi_bar=self.avg_gene_expression)
+            mu_cell = self.calculate_mu(epsilon=epsilon,
+                                        d_cell=d_cell,
+                                        chi=chi,
+                                        y=y,
+                                        rho=rho)
 
-            # Sample actual gene expression, and compare with observed data.
+            if self.include_empties:
 
-            # Poisson:
-            # pyro.sample("obs", dist.Poisson(mu).independent(1),
-            #             obs=x.reshape(-1, self.n_genes))
+                # Calculate the background rate parameter (for each barcode).
+                lam = self.calculate_lambda(epsilon=epsilon,
+                                            chi_ambient=chi_ambient,
+                                            d_empty=d_empty,
+                                            y=y,
+                                            d_cell=d_cell,
+                                            rho=rho,
+                                            chi_bar=self.avg_gene_expression)
+            else:
+                lam = torch.zeros([self.n_genes]).to(self.device)
 
-            # Negative binomial:
-            r = 1. / phi
-            logit = torch.log(mu * phi)
-            pyro.sample("obs", dist.NegativeBinomial(total_count=r,
-                                                     logits=logit).to_event(1),
-                        obs=x.reshape(-1, self.n_genes))
+            alpha = phi.reciprocal()
+
+            if self.use_exact_log_prob:
+
+                # Sample gene expression from our Negative Binomial Poisson
+                # Convolution distribution, and compare with observed data.
+                c = pyro.sample("obs", NBPC(mu=mu_cell + consts.NBPC_MU_EPS_SAFEGAURD,
+                                            alpha=alpha + consts.NBPC_ALPHA_EPS_SAFEGAURD,
+                                            lam=lam + consts.NBPC_LAM_EPS_SAFEGAURD,
+                                            max_poisson=consts.NBPC_EXACT_N_TERMS).to_event(1),
+                                obs=x.reshape(-1, self.n_genes))
+
+            else:
+
+                # Use a negative binomial approximation as the observation model.
+                c = pyro.sample("obs", NBPCapprox(mu=mu_cell + consts.NBPC_MU_EPS_SAFEGAURD,
+                                                  alpha=alpha + consts.NBPC_ALPHA_EPS_SAFEGAURD,
+                                                  lam=lam + consts.NBPC_LAM_EPS_SAFEGAURD).to_event(1),
+                                obs=x.reshape(-1, self.n_genes))
+
+            if self.include_empties:
+
+                # Put a prior on p_y_logit to maintain balance.
+                pyro.sample("p_logit_reg", dist.Normal(loc=self.p_logit_prior,
+                                                       scale=(consts.P_LOGIT_SCALE
+                                                              * torch.ones([1]).to(self.device))))
+
+                # Additionally use the surely empty droplets for regularization,
+                # since we know these droplets by their UMI counts.
+                counts = x.sum(dim=-1, keepdim=False)
+                surely_empty_mask = ((counts < self.empty_UMI_threshold)
+                                     .bool().to(self.device))
+
+                with poutine.mask(mask=surely_empty_mask):
+
+                    with poutine.scale(scale=consts.REG_SCALE_AMBIENT_EXPRESSION):
+
+                        if self.include_rho:
+                            r = rho.detach()
+                        else:
+                            r = None
+
+                        # Semi-supervision of ambient expression.
+                        lam = self.calculate_lambda(epsilon=epsilon.detach(),
+                                                    chi_ambient=chi_ambient,
+                                                    d_empty=d_empty,
+                                                    y=torch.zeros_like(d_empty),
+                                                    d_cell=d_cell.detach(),
+                                                    rho=r,
+                                                    chi_bar=self.avg_gene_expression)
+                        pyro.sample("obs_empty",
+                                    dist.Poisson(rate=lam + 1e-10).to_event(1),
+                                    obs=x.reshape(-1, self.n_genes))
+
+                    # Semi-supervision of cell probabilities.
+                    with poutine.scale(scale=consts.REG_SCALE_EMPTY_PROB):
+
+                        p_logit_posterior = pyro.sample("p_passback",
+                                                        NullDist(torch.zeros(1)
+                                                                 .to(self.device))
+                                                        .expand_by([x.size(0)]))
+
+                        pyro.sample("obs_empty_y",
+                                    dist.Normal(loc=p_logit_posterior,
+                                                scale=1.),
+                                    obs=torch.ones_like(y) * -5.)
+
+                # Additionally use some high-count droplets for cell prob regularization.
+                surely_cell_mask = (torch.where(counts >= self.d_cell_loc_prior.exp(),
+                                                torch.ones_like(counts),
+                                                torch.zeros_like(counts))
+                                    .bool().to(self.device))
+
+                with poutine.mask(mask=surely_cell_mask):
+                    with poutine.scale(scale=consts.REG_SCALE_CELL_PROB):
+                        pyro.sample("obs_cell_y",
+                                    dist.Normal(loc=p_logit_posterior,
+                                                scale=1.),
+                                    obs=torch.ones_like(y) * 5.)
+
+        return {'mu': mu_cell, 'lam': lam, 'alpha': alpha, 'counts': c}
 
     @config_enumerate(default='parallel')
     def guide(self, x: torch.Tensor):
@@ -354,14 +402,20 @@ class RemoveBackgroundPyroModel(nn.Module):
 
         """
 
+        nan_check = False
+
+        if nan_check:
+            for param in pyro.get_param_store().keys():
+                if torch.isnan(pyro.param(param).sum()):
+                    raise NanException(param)
+
         # Register the encoder(s) with pyro.
         for name, module in self.encoder.items():
             pyro.module("encoder_" + name, module)
 
         # Initialize variational parameters for d_cell.
         d_cell_scale = pyro.param("d_cell_scale",
-                                  self.d_cell_scale_prior *
-                                  torch.ones(torch.Size([])).to(self.device),
+                                  torch.tensor([consts.D_CELL_SCALE_INIT]).to(self.device),
                                   constraint=constraints.positive)
 
         if self.include_empties:
@@ -388,11 +442,13 @@ class RemoveBackgroundPyroModel(nn.Module):
             rho_alpha = pyro.param("rho_alpha",
                                    self.rho_alpha_prior *
                                    torch.ones(torch.Size([])).to(self.device),
-                                   constraint=constraints.positive)
+                                   constraint=constraints.interval(consts.RHO_PARAM_MIN,
+                                                                   consts.RHO_PARAM_MAX))  # Prevent NaNs
             rho_beta = pyro.param("rho_beta",
                                   self.rho_beta_prior *
                                   torch.ones(torch.Size([])).to(self.device),
-                                  constraint=constraints.positive)
+                                  constraint=constraints.interval(consts.RHO_PARAM_MIN,
+                                                                  consts.RHO_PARAM_MAX))
 
         # Initialize variational parameters for phi.
         phi_loc = pyro.param("phi_loc",
@@ -413,263 +469,76 @@ class RemoveBackgroundPyroModel(nn.Module):
         with pyro.plate("data", x.size(0),
                         use_cuda=self.use_cuda, device=self.device):
 
+            # Sample swapping fraction rho.
+            if self.include_rho:
+                rho = pyro.sample("rho", dist.Beta(rho_alpha,
+                                                   rho_beta).expand_by([x.size(0)]))
+
             # Encode the latent variables from the input gene expression counts.
             if self.include_empties:
+
+                # Sample d_empty, which doesn't depend on y.
+                d_empty = pyro.sample("d_empty",
+                                      dist.LogNormal(loc=d_empty_loc,
+                                                     scale=d_empty_scale)
+                                      .expand_by([x.size(0)]))
+
                 enc = self.encoder.forward(x=x, chi_ambient=chi_ambient)
 
             else:
                 enc = self.encoder.forward(x=x, chi_ambient=None)
 
-            # Sample swapping fraction rho.
-            if self.include_rho:
-                pyro.sample("rho", dist.Beta(rho_alpha,
-                                             rho_beta).expand_by([x.size(0)]))
-
             # Code specific to models with empty droplets.
             if self.include_empties:
 
-                # Sample d_empty, which doesn't depend on y.
-                pyro.sample("d_empty",
-                            dist.LogNormal(d_empty_loc,
-                                           d_empty_scale)
-                            .expand_by([x.size(0)]))
+                # Regularize based on wanting a balanced p_y_logit.
+                pyro.sample("p_logit_reg", dist.Normal(loc=enc['p_y'], scale=consts.P_LOGIT_SCALE))
 
-                # Mask out the barcodes which are likely to be empty droplets.
-                masking = (enc['p_y'] >= 0).to(self.device, dtype=torch.float32)
-
-                # Sample latent code z for the barcodes containing real cells.
-                pyro.sample("z",
-                            dist.Normal(enc['z']['loc'],
-                                        enc['z']['scale'])
-                            .to_event(1).mask(masking))
+                # Pass back the inferred p_y to the model.
+                pyro.sample("p_passback", NullDist(enc['p_y'].detach()))
 
                 # Sample the Bernoulli y from encoded p(y).
-                pyro.sample("y", dist.Bernoulli(logits=enc['p_y']))
+                y = pyro.sample("y", dist.Bernoulli(logits=enc['p_y']))
 
                 # Gate d_cell_loc so empty droplets do not give big gradients.
                 prob = enc['p_y'].sigmoid()  # Logits to probability
                 d_cell_loc_gated = (prob * enc['d_loc'] + (1 - prob)
-                                    * self.d_cell_loc_prior)
+                                    * self.d_cell_loc_prior)  # NOTE: necessary to pass on sim6
 
-                # Sample d based the encoding.
-                pyro.sample("d_cell", dist.LogNormal(d_cell_loc_gated,
-                                                     d_cell_scale))
+                # Sample d based on the encoding.
+                d_cell = pyro.sample("d_cell", dist.LogNormal(loc=d_cell_loc_gated,
+                                                              scale=d_cell_scale))
+
+                # Mask out empty droplets.
+                with poutine.mask(mask=y.bool()):
+
+                    # Sample latent code z for the barcodes containing cells.
+                    pyro.sample("z",
+                                dist.Normal(loc=enc['z']['loc'],
+                                            scale=enc['z']['scale'])
+                                .to_event(1))
+
+                    # Gate epsilon and sample.
+                    epsilon_gated = (prob * enc['epsilon'] + (1 - prob) * 1.)
+
+                    epsilon = pyro.sample("epsilon",
+                                          dist.Gamma(epsilon_gated * self.epsilon_prior,
+                                                     self.epsilon_prior))
 
             else:
 
-                # Sample d based the encoding.
-                pyro.sample("d_cell", dist.LogNormal(enc['d_loc'],
-                                                     d_cell_scale))
+                # Sample d based on the encoding.
+                pyro.sample("d_cell", dist.LogNormal(loc=enc['d_loc'],
+                                                     scale=d_cell_scale))
 
                 # Sample latent code z for each cell.
-                pyro.sample("z", dist.Normal(enc['z']['loc'],
-                                             enc['z']['scale']).independent(1))
+                pyro.sample("z",
+                            dist.Normal(loc=enc['z']['loc'],
+                                        scale=enc['z']['scale'])
+                            .to_event(1))
 
 
-def get_encodings(model: RemoveBackgroundPyroModel,
-                  dataset_obj: 'SingleCellRNACountsDataset',
-                  cells_only: bool = True) -> Tuple[np.ndarray,
-                                                    np.ndarray,
-                                                    np.ndarray]:
-    """Get inferred quantities from a trained model.
-
-    Run a dataset through the model's trained encoder and return the inferred
-    quantities.
-
-    Args:
-        model: A trained cellbender.model.VariationalInferenceModel, which will
-            be used to generate the encodings from data.
-        dataset_obj: The dataset to be encoded.
-        cells_only: If True, only returns the encodings of barcodes that are
-            determined to contain cells.
-
-    Returns:
-        z: Latent variable embedding of gene expression in a low-dimensional
-            space.
-        d: Latent variable scale factor for the number of UMI counts coming
-            from each real cell.  Not in log space, but actual size.  This is
-            not just the encoded d, but the mean of the LogNormal distribution,
-            which is exp(mean + sigma^2 / 2).
-        p: Latent variable denoting probability that each barcode contains a
-            real cell.
-
-    """
-
-    logging.info("Encoding data according to model.")
-
-    # Get the count matrix with genes trimmed.
-    if cells_only:
-        dataset = dataset_obj.get_count_matrix()
-    else:
-        dataset = dataset_obj.get_count_matrix_all_barcodes()
-
-    # Initialize numpy arrays as placeholders.
-    z = np.zeros((dataset.shape[0], model.z_dim))
-    d = np.zeros((dataset.shape[0]))
-    p = np.zeros((dataset.shape[0]))
-
-    # Get chi ambient, if it was part of the model.
-    chi_ambient = get_ambient_expression_from_pyro_param_store()
-    if chi_ambient is not None:
-        chi_ambient = torch.Tensor(chi_ambient).to(device=model.device)
-
-    # Send dataset through the learned encoder in chunks.
-    s = 200
-    for i in np.arange(0, dataset.shape[0], s):
-
-        # Put chunk of data into a torch.Tensor.
-        x = torch.Tensor(np.array(
-            dataset[i:min(dataset.shape[0], i + s), :].todense(),
-            dtype=int).squeeze()).to(device=model.device)
-
-        # Send data chunk through encoder.
-        enc = model.encoder.forward(x=x, chi_ambient=chi_ambient)
-
-        # Get d_cell_scale from fit model.
-        d_sig = to_ndarray(pyro.get_param_store().get_param('d_cell_scale'))
-
-        # Put the resulting encodings into the appropriate numpy arrays.
-        z[i:min(dataset.shape[0], i + s), :] = to_ndarray(enc['z']['loc'])
-        d[i:min(dataset.shape[0], i + s)] = (np.exp(to_ndarray(enc['d_loc']))
-                                             + d_sig.item()**2 / 2)
-        try:  # p is not always available: it depends which model was used.
-            p[i:min(dataset.shape[0], i + s)] = to_ndarray(enc['p_y'].sigmoid())
-        except KeyError:
-            p = None  # Simple model gets None for p.
-
-    return z, d, p
-
-
-def generate_maximum_a_posteriori_count_matrix(
-        z: np.ndarray,
-        d: np.ndarray,
-        p: Union[np.ndarray, None],
-        model: RemoveBackgroundPyroModel,
-        dataset_obj: 'SingleCellRNACountsDataset',
-        cells_only: bool = True,
-        chunk_size: int = 200) -> sp.csc.csc_matrix:
-    """Make a point estimate of ambient-background-subtracted UMI count matrix.
-
-    Sample counts by maximizing the model posterior based on learned latent
-    variables.  The output matrix is in sparse form.
-
-    Args:
-        z: Latent variable embedding of gene expression in a low-dimensional
-            space.
-        d: Latent variable scale factor for the number of UMI counts coming
-            from each real cell.
-        p: Latent variable denoting probability that each barcode contains a
-            real cell.
-        model: Model with latent variables already inferred.
-        dataset_obj: Input dataset.
-        cells_only: If True, only returns the encodings of barcodes that are
-            determined to contain cells.
-        chunk_size: Size of mini-batch of data to send through encoder at once.
-
-    Returns:
-        inferred_count_matrix: Matrix of the same dimensions as the input
-            matrix, but where the UMI counts have had ambient-background
-            subtracted.
-
-    Note:
-        This currently uses the MAP estimate of draws from a Poisson (or a
-        negative binomial with zero overdispersion).
-
-    """
-
-    # If simple model was used, then p = None.  Here set it to 1.
-    if p is None:
-        p = np.ones_like(d)
-
-    # Get the count matrix with genes trimmed.
-    if cells_only:
-        count_matrix = dataset_obj.get_count_matrix()
-    else:
-        count_matrix = dataset_obj.get_count_matrix_all_barcodes()
-
-    logging.info("Getting ambient-background-subtracted UMI count matrix.")
-
-    # Ensure there are no nans in p (there shouldn't be).
-    p_no_nans = p
-    p_no_nans[np.isnan(p)] = 0  # Just make sure there are no nans.
-
-    # Trim everything down to the barcodes we are interested in (just cells?).
-    if cells_only:
-        d = d[p_no_nans > consts.CELL_PROB_CUTOFF]
-        z = z[p_no_nans > consts.CELL_PROB_CUTOFF, :]
-        barcode_inds = \
-            dataset_obj.analyzed_barcode_inds[p_no_nans
-                                              > consts.CELL_PROB_CUTOFF]
-    else:
-        # Set cell size factors equal to zero where cell probability < 0.5.
-        d[p_no_nans < consts.CELL_PROB_CUTOFF] = 0.
-        z[p_no_nans < consts.CELL_PROB_CUTOFF, :] = 0.
-        barcode_inds = np.arange(0, count_matrix.shape[0])  # All barcodes
-
-    # Get mean of the inferred posterior for the overdispersion, phi.
-    phi = to_ndarray(pyro.get_param_store().get_param("phi_loc")).item()
-
-    # Get the gene expression vectors by sending latent z through the decoder.
-    # Send dataset through the learned encoder in chunks.
-    barcodes = []
-    genes = []
-    counts = []
-    s = chunk_size
-    for i in np.arange(0, barcode_inds.size, s):
-
-        # TODO: for 117000 cells, this routine overflows (~15GB) memory
-
-        last_ind_this_chunk = min(count_matrix.shape[0], i+s)
-
-        # Decode gene expression for a chunk of barcodes.
-        decoded = model.decoder(torch.Tensor(
-            z[i:last_ind_this_chunk]).to(device=model.device))
-        chi = to_ndarray(decoded)
-
-        # Estimate counts for the chunk of barcodes as d * chi.
-        chunk_dense_counts = \
-            np.maximum(0,
-                       np.expand_dims(d[i:last_ind_this_chunk], axis=1) * chi)
-
-        # Turn the floating point count estimates into integers.
-        decimal_values, _ = np.modf(chunk_dense_counts)  # Stuff after decimal.
-        roundoff_counts = np.random.binomial(1, p=decimal_values)  # Bernoulli.
-        chunk_dense_counts = np.floor(chunk_dense_counts).astype(dtype=int)
-        chunk_dense_counts += roundoff_counts
-
-        # Find all the nonzero counts in this dense matrix chunk.
-        nonzero_barcode_inds_this_chunk, nonzero_genes_trimmed = \
-            np.nonzero(chunk_dense_counts)
-        nonzero_counts = \
-            chunk_dense_counts[nonzero_barcode_inds_this_chunk,
-                               nonzero_genes_trimmed].flatten(order='C')
-
-        # Get the original gene index from gene index in the trimmed dataset.
-        nonzero_genes = dataset_obj.analyzed_gene_inds[nonzero_genes_trimmed]
-
-        # Get the actual barcode values.
-        nonzero_barcode_inds = nonzero_barcode_inds_this_chunk + i
-        nonzero_barcodes = barcode_inds[nonzero_barcode_inds]
-
-        # Append these to their lists.
-        barcodes.extend(nonzero_barcodes.astype(dtype=np.uint32))
-        genes.extend(nonzero_genes.astype(dtype=np.uint32))
-        counts.extend(nonzero_counts.astype(dtype=np.uint32))
-
-    # Convert the lists to numpy arrays.
-    counts = np.array(counts, dtype=np.uint32)
-    barcodes = np.array(barcodes, dtype=np.uint32)
-    genes = np.array(genes, dtype=np.uint32)
-
-    # Put the counts into a sparse csc_matrix.
-    inferred_count_matrix = sp.csc_matrix((counts, (barcodes, genes)),
-                                          shape=dataset_obj.data['matrix']
-                                          .shape)
-
-    return inferred_count_matrix
-
-
-def get_ambient_expression_from_pyro_param_store() -> Union[np.ndarray, None]:
+def get_ambient_expression() -> Optional[np.ndarray]:
     """Get ambient RNA expression for 'empty' droplets.
 
     Return:
@@ -684,75 +553,46 @@ def get_ambient_expression_from_pyro_param_store() -> Union[np.ndarray, None]:
 
     chi_ambient = None
 
-    try:
-        # Get fit hyperparameter for ambient gene expression from model.
-        chi_ambient = to_ndarray(pyro.param("chi_ambient")).squeeze()
-    except KeyError:
-        pass
+    if 'chi_ambient' in pyro.get_param_store().keys():
+        chi_ambient = to_ndarray(pyro.param('chi_ambient')).squeeze()
 
     return chi_ambient
 
 
-def get_contamination_fraction() -> Union[np.ndarray, None]:
-    """Get barcode swapping contamination fraction hyperparameters.
+def get_rho() -> Optional[np.ndarray]:
+    """Get ambient RNA expression for 'empty' droplets.
 
     Return:
-        rho: The alpha and beta parameters of the Beta distribution for the
-            contamination fraction.
+        chi_ambient: The ambient gene expression profile, as a normalized
+            vector that sums to one.
 
     Note:
-        Inference must have been performed on a model with 'rho_alpha' and
-        'rho_beta' hyperparameters prior to making this call.
+        Inference must have been performed on a model with a 'chi_ambient'
+        hyperparameter prior to making this call.
 
     """
 
     rho = None
 
-    try:
-        # Get fit hyperparameters for contamination fraction from model.
-        rho_alpha = to_ndarray(pyro.param("rho_alpha")).squeeze()
-        rho_beta = to_ndarray(pyro.param("rho_beta")).squeeze()
-        rho = np.array([rho_alpha, rho_beta])
-    except KeyError:
-        pass
+    if 'rho_alpha' in pyro.get_param_store().keys() \
+            and 'rho_beta' in pyro.get_param_store().keys():
+        rho = np.array([to_ndarray(pyro.param('rho_alpha')).item(),
+                        to_ndarray(pyro.param('rho_beta')).item()])
 
     return rho
-
-
-def get_overdispersion_from_pyro_param_store() -> Union[np.ndarray, None]:
-    """Get overdispersion hyperparameters.
-
-    Return:
-        phi: The mean and stdev parameters of the Gamma distribution for the
-            contamination fraction.
-
-    Note:
-        Inference must have been performed on a model with 'phi_loc' and
-        'phi_scale' hyperparameters prior to making this call.
-
-    """
-
-    phi = None
-
-    try:
-        # Get fit hyperparameters for contamination fraction from model.
-        phi_loc = to_ndarray(pyro.param("phi_loc")).squeeze()
-        phi_scale = to_ndarray(pyro.param("phi_scale")).squeeze()
-        phi = np.array([phi_loc, phi_scale])
-    except KeyError:
-        pass
-
-    return phi
 
 
 def to_ndarray(x: Union[Number, np.ndarray, torch.Tensor]) -> np.ndarray:
     """Convert a numeric value or array to a numpy array on cpu."""
 
-    if type(x) is Number:
-        return np.array(x)
-
-    elif type(x) is np.ndarray:
+    if type(x) is np.ndarray:
         return x
 
     elif type(x) is torch.Tensor:
         return x.detach().cpu().numpy()
+
+    elif type(x) is Number:
+        return np.array(x)
+
+    else:
+        raise TypeError(f'to_ndarray() received input of type {type(x)}')

--- a/cellbender/remove_background/train.py
+++ b/cellbender/remove_background/train.py
@@ -10,25 +10,33 @@ from pyro.util import ignore_jit_warnings
 from cellbender.remove_background.model import RemoveBackgroundPyroModel
 from cellbender.remove_background.vae.decoder import Decoder
 from cellbender.remove_background.vae.encoder \
-    import EncodeZ, EncodeD, EncodeNonEmptyDropletLogitProb, CompositeEncoder
+    import EncodeZ, CompositeEncoder, EncodeNonZLatents
 from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset
 from cellbender.remove_background.data.dataprep import \
     prep_sparse_data_for_training as prep_data_for_training
 from cellbender.remove_background.data.dataprep import DataLoader
+from cellbender.remove_background.exceptions import NanException
+import cellbender.remove_background.consts as consts
 
 import numpy as np
+import torch
 
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 import logging
+import time
+from datetime import datetime
 
 
 def train_epoch(svi: SVI,
-                train_loader: DataLoader) -> float:
+                train_loader: DataLoader,
+                epoch: Optional[int] = None) -> float:
     """Train a single epoch.
 
     Args:
         svi: The pyro object used for stochastic variational inference.
         train_loader: Dataloader for training set.
+        epoch: Epoch used by the learning rate scheduler.  Use None for normal
+            schedule.  Can co-opt the schedule by setting a value (cool off).
 
     Returns:
         total_epoch_loss_train: The loss for this epoch of training, which is
@@ -45,6 +53,7 @@ def train_epoch(svi: SVI,
 
         # Perform gradient descent step and accumulate loss.
         epoch_loss += svi.step(x_cell_batch)
+        svi.optim.step(epoch=epoch)  # for LR scheduling
         normalizer_train += x_cell_batch.size(0)
 
     # Return epoch loss.
@@ -120,15 +129,24 @@ def run_training(model: RemoveBackgroundPyroModel,
 
     # Run training loop.  Use try to allow for keyboard interrupt.
     try:
-        for epoch in range(epochs):
+        for epoch in range(1, epochs + 1):
 
-            # Train, and keep track of training loss.
+            # Display duration of an epoch (use 2 to avoid initializations).
+            if epoch == 2:
+                t = time.time()
+
             total_epoch_loss_train = train_epoch(svi, train_loader)
+
             train_elbo.append(-total_epoch_loss_train)
             model.loss['train']['epoch'].append(epoch)
             model.loss['train']['elbo'].append(-total_epoch_loss_train)
-            logging.info("[epoch %03d]  average training loss: %.4f"
-                         % (epoch, total_epoch_loss_train))
+
+            if epoch == 2:
+                logging.info("[epoch %03d]  average training loss: %.4f  (%.1f seconds per epoch)"
+                             % (epoch, total_epoch_loss_train, time.time() - t))
+            else:
+                logging.info("[epoch %03d]  average training loss: %.4f"
+                             % (epoch, total_epoch_loss_train))
 
             # If there is no test data (training_fraction == 1.), skip test.
             if len(test_loader) == 0:
@@ -149,6 +167,15 @@ def run_training(model: RemoveBackgroundPyroModel,
     except KeyboardInterrupt:
 
         logging.info("Inference procedure stopped by keyboard interrupt.")
+
+    # Exception allows program to produce output when terminated by a NaN.
+    except NanException as nan:
+
+        print(nan.message)
+        logging.info(f"Inference procedure terminated early due to a NaN value in: {nan.param}\n\n"
+                     f"The suggested fix is to reduce the learning rate.\n\n")
+
+    logging.info(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
     return train_elbo, test_elbo
 
@@ -185,29 +212,15 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
                         output_dim=args.z_dim,
                         input_transform='normalize')
 
-    encoder_d = EncodeD(input_dim=count_matrix.shape[1],
-                        hidden_dims=args.d_hidden_dims,
-                        output_dim=1,
-                        log_count_crossover=
-                        dataset_obj.priors['log_counts_crossover'])
+    encoder_other = EncodeNonZLatents(n_genes=count_matrix.shape[1],
+                                      z_dim=args.z_dim,
+                                      hidden_dims=consts.ENC_HIDDEN_DIMS,
+                                      log_count_crossover=dataset_obj.priors['log_counts_crossover'],
+                                      prior_log_cell_counts=np.log1p(dataset_obj.priors['cell_counts']),
+                                      input_transform='normalize')
 
-    if args.model == "simple":
-
-        # If using the simple model, there is no need for p.
-        encoder = CompositeEncoder({'z': encoder_z, 'd_loc': encoder_d})
-
-    else:
-
-        # Models that include empty droplets.
-        encoder_p = EncodeNonEmptyDropletLogitProb(
-            input_dim=count_matrix.shape[1],
-            hidden_dims=args.p_hidden_dims,
-            output_dim=1,
-            input_transform='normalize',
-            log_count_crossover=dataset_obj.priors['log_counts_crossover'])
-        encoder = CompositeEncoder({'z': encoder_z,
-                                    'd_loc': encoder_d,
-                                    'p_y': encoder_p})
+    encoder = CompositeEncoder({'z': encoder_z,
+                                'other': encoder_other})
 
     # Decoder.
     decoder = Decoder(input_dim=args.z_dim,
@@ -221,31 +234,9 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
                                       dataset_obj=dataset_obj,
                                       use_cuda=args.use_cuda)
 
-    # Set up the optimizer.
-    adam_args = {"lr": args.learning_rate}
-    optimizer = ClippedAdam(adam_args)
-
-    # Determine the loss function.
-    if args.use_jit:
-        loss_function = JitTraceEnum_ELBO(max_plate_nesting=1,
-                                          strict_enumeration_warning=False)
-    else:
-        loss_function = TraceEnum_ELBO(max_plate_nesting=1)
-
-    if args.model == "simple":
-        if args.use_jit:
-            loss_function = JitTrace_ELBO()
-        else:
-            loss_function = Trace_ELBO()
-
-    # Set up the inference process.
-    svi = SVI(model.model, model.guide, optimizer,
-              loss=loss_function)
-
     # Load the dataset into DataLoaders.
     frac = args.training_fraction  # Fraction of barcodes to use for training
-    batch_size = int(min(500,
-                         frac * dataset_obj.analyzed_barcode_inds.size / 2))
+    batch_size = int(min(300, frac * dataset_obj.analyzed_barcode_inds.size / 2))
     train_loader, test_loader = \
         prep_data_for_training(dataset=count_matrix,
                                empty_drop_dataset=
@@ -257,8 +248,43 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
                                shuffle=True,
                                use_cuda=args.use_cuda)
 
+    # Set up the optimizer.
+    optimizer = pyro.optim.clipped_adam.ClippedAdam
+    optimizer_args = {'lr': args.learning_rate, 'clip_norm': 10.}
+
+    # Set up a learning rate scheduler.
+    minibatches_per_epoch = int(np.ceil(len(train_loader) / train_loader.batch_size).item())
+    scheduler_args = {'optimizer': optimizer,
+                      'max_lr': args.learning_rate * 10,
+                      'steps_per_epoch': minibatches_per_epoch,
+                      'epochs': args.epochs,
+                      'optim_args': optimizer_args}
+    scheduler = pyro.optim.OneCycleLR(scheduler_args)
+
+    # Determine the loss function.
+    if args.use_jit:
+
+        # Call guide() once as a warm-up.
+        model.guide(torch.zeros([10, dataset_obj.analyzed_gene_inds.size]).to(model.device))
+
+        if args.model == "simple":
+            loss_function = JitTrace_ELBO()
+        else:
+            loss_function = JitTraceEnum_ELBO(max_plate_nesting=1,
+                                              strict_enumeration_warning=False)
+    else:
+
+        if args.model == "simple":
+            loss_function = Trace_ELBO()
+        else:
+            loss_function = TraceEnum_ELBO(max_plate_nesting=1)
+
+    # Set up the inference process.
+    svi = SVI(model.model, model.guide, scheduler,
+              loss=loss_function)
+
     # Run training.
     run_training(model, svi, train_loader, test_loader,
-                 epochs=args.epochs, test_freq=10)
+                 epochs=args.epochs, test_freq=5)
 
     return model

--- a/cellbender/remove_background/vae/decoder.py
+++ b/cellbender/remove_background/vae/decoder.py
@@ -36,7 +36,10 @@ class Decoder(nn.Module):
 
     """
 
-    def __init__(self, input_dim: int, hidden_dims: List[int], output_dim: int,
+    def __init__(self,
+                 input_dim: int,
+                 hidden_dims: List[int],
+                 output_dim: int,
                  log_output: bool = False):
         super(Decoder, self).__init__()
         self.input_dim = input_dim

--- a/cellbender/remove_background/vae/encoder.py
+++ b/cellbender/remove_background/vae/encoder.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
-from typing import Dict, List, Union
-import warnings
+
+from typing import Dict, List, Optional
 
 
 class CompositeEncoder(dict):
@@ -25,10 +25,24 @@ class CompositeEncoder(dict):
 
     def forward(self, **kwargs) \
             -> Dict[str, torch.Tensor]:
-        # For each module in the dict of the composite encoder, call forward().
+
         out = dict()
+        # Encode z first.
+        out['z'] = self.module_dict['z'].forward(**kwargs)
+
+        # For each other module in the dict of the composite encoder,
+        # call forward(), and pass in the encoded z.
         for key, value in self.module_dict.items():
-            out[key] = value.forward(**kwargs)
+
+            if key == 'z':
+                continue  # already done
+
+            out[key] = value.forward(**kwargs, z=out['z']['loc'].detach())
+
+            if key == 'other':
+                for subkey, value in out[key].items():
+                    out[subkey] = value
+                del out[key]
 
         return out
 
@@ -75,6 +89,7 @@ class EncodeZ(nn.Module):
                  input_transform: str = None):
         super(EncodeZ, self).__init__()
         self.input_dim = input_dim
+        self.output_dim = output_dim
         self.transform = input_transform
 
         # Set up the linear transformations used in fully-connected layers.
@@ -107,184 +122,212 @@ class EncodeZ(nn.Module):
         return {'loc': loc.squeeze(), 'scale': scale.squeeze()}
 
 
-class EncodeD(nn.Module):
-    """Encoder module that transforms gene expression into latent cell size.
+class EncodeNonZLatents(nn.Module):
+    """Encoder module that transforms data into all latents except z.
 
-    The number of input units is the total number of genes and the number of
-    output units is the dimension of the latent space.  This encoder transforms
-    a point in high-dimensional gene expression space to a latent cell size
-    estimate, via a learned transformation involving fully-connected
-    layers.
+    The number of input units is the total number of genes plus four
+    hand-crafted features, and the number of output units is 3: these being
+    latents logit_p, d, epsilon.  This encoder transforms
+    a point in high-dimensional gene expression space into latents.  This
+    encoder uses both the gene expression counts as well as an estimate of the
+    ambient RNA profile in order to compute latents.
 
     Args:
-        input_dim: Number of genes.  The size of the input of this encoder.
+        n_genes: Number of genes.  The size of the input of this encoder.
+        z_dim: Dimension of latent encoding of gene expression, z.
         hidden_dims: Size of each of the hidden layers.
-        output_dim: Number of dimensions of the size estimate (1).
         input_transform: Name of transformation to be applied to the input
             gene expression counts.  Must be one of
-            ['log', 'normalize', 'log_center'].
+            ['log', 'normalize', 'log_center', None].
         log_count_crossover: The log of the number of counts where the
             transition from cells to empty droplets is expected to occur.
+        prior_log_cell_counts: Natural log of expected counts per cell.
 
     Attributes:
         transform: Name of transformation to be applied to the input gene
             expression counts.
-        param: The log of the number of counts where the transition from
-            cells to empty droplets is expected to occur.
-        linears: torch.nn.ModuleList of fully-connected layers before the
-            output layer.
-        output: torch.nn.Linear fully-connected output layer for the size
-            of each input barcode.
-        input_dim: Size of input gene expression.
-
-    Note:
-        An encoder with two hidden layers with sizes 100 and 500, respectively,
-        should set hidden_dims = [100, 500].  An encoder with only one hidden
-        layer should still pass in hidden_dims as a list, for example,
-        hidden_dims = [500].
-        This encoder acts as if each barcode input contains a cell.  In reality,
-        barcodes that do not contain a cell will not propagate gradients back
-        to this encoder, due to the design of the rest of the model.
-
-    """
-
-    def __init__(self, input_dim: int, hidden_dims: List[int], output_dim: int,
-                 input_transform: str = None, log_count_crossover: float = 7.):
-        super(EncodeD, self).__init__()
-        self.input_dim = input_dim
-        self.transform = input_transform
-        self.param = log_count_crossover
-
-        # Set up the linear transformations used in fully-connected layers.
-        self.linears = nn.ModuleList([nn.Linear(input_dim, hidden_dims[0])])
-        for i in range(1, len(hidden_dims)):  # Second hidden layer onward
-            self.linears.append(nn.Linear(hidden_dims[i-1], hidden_dims[i]))
-        self.output = nn.Linear(hidden_dims[-1], output_dim)
-
-        # Set up the non-linear activations.
-        self.softplus = nn.Softplus()
-
-    def forward(self, x: torch.Tensor, **kwargs) -> torch.Tensor:
-        # Define the forward computation to go from gene expression to cell
-        # probabilities.
-
-        # Transform input and calculate log total UMI counts per barcode.
-        x = x.reshape(-1, self.input_dim)
-        log_sum = x.sum(dim=-1, keepdim=True).log1p()
-        x = transform_input(x, self.transform)
-
-        # Compute the hidden layers and the output.
-        hidden = self.softplus(self.linears[0](x))
-        for i in range(1, len(self.linears)):  # Second hidden layer onward
-            hidden = self.softplus(self.linears[i](hidden))
-
-        return self.softplus(self.output(hidden)
-                             + self.softplus(log_sum - self.param)
-                             + self.param).squeeze()
-
-
-class EncodeNonEmptyDropletLogitProb(nn.Module):
-    """Encoder module that transforms gene expression into cell probabilities.
-
-    The number of input units is the total number of genes and the number of
-    output units is the dimension of the latent space.  This encoder transforms
-    a point in high-dimensional gene expression space to a latent probability
-    that a given barcode contains a real cell, via a learned transformation
-    involving fully-connected layers.  This encoder uses both the gene
-    expression counts as well as an estimate of the ambient RNA profile in
-    order to output a cell probability.
-
-    Args:
-        input_dim: Number of genes.  The size of the input of this encoder.
-        hidden_dims: Size of each of the hidden layers.
-        output_dim: Number of dimensions of the probability estimate (1).
-        input_transform: Name of transformation to be applied to the input
-            gene expression counts.  Must be one of
-            ['log', 'normalize', 'log_center'].
         log_count_crossover: The log of the number of counts where the
             transition from cells to empty droplets is expected to occur.
-
-    Attributes:
-        transform: Name of transformation to be applied to the input gene
-            expression counts.
-        param: The log of the number of counts where the transition from
-            cells to empty droplets is expected to occur.
         linears: torch.nn.ModuleList of fully-connected layers before the
             output layer.
         output: torch.nn.Linear fully-connected output layer for the size
             of each input barcode.
-        input_dim: Size of input gene expression.
+        n_genes: Size of input gene expression.
 
-    Note:
+    Returns:
+        output: Dict containing -
+            logit_p: Logit probability that droplet contains a cell
+            d: Cell size scale factor
+            epsilon: Value near one that represents droplet RT efficiency
+
+    Notes:
         An encoder with two hidden layers with sizes 100 and 500, respectively,
         should set hidden_dims = [100, 500].  An encoder with only one hidden
         layer should still pass in hidden_dims as a list, for example,
         hidden_dims = [500].
-        The output is in the form of a logit, so can be any real number.  The
-        transformation from logit to probability is a sigmoid.
+        The output is in the form of a dict.  Ouput for cell probability is a
+        logit, so can be any real number.  The transformation from logit to
+        probability is a sigmoid.
+        Several heuristics are used to try to encourage a good initialization.
 
     """
 
-    def __init__(self, input_dim: int, hidden_dims: List[int], output_dim: int,
-                 log_count_crossover: float, input_transform: str = None):
-        super(EncodeNonEmptyDropletLogitProb, self).__init__()
-        self.input_dim = input_dim
+    def __init__(self,
+                 n_genes: int,
+                 z_dim: int,
+                 hidden_dims: List[int],
+                 log_count_crossover: float,  # prior on log counts of smallest cell
+                 prior_log_cell_counts: int,  # prior on counts per cell
+                 input_transform: Optional[str] = None):
+        super(EncodeNonZLatents, self).__init__()
+        self.n_genes = n_genes
+        self.z_dim = z_dim
         self.transform = input_transform
-        self.param = log_count_crossover
-        self.INITIAL_WEIGHT_FOR_LOG_COUNTS = 1.
-        self.INITIAL_OUTPUT_SCALE_FOR_LOG_COUNTS = 5.
-        self.INITIAL_OUTPUT_BIAS_FOR_LOG_COUNTS = \
-            -1 * self.INITIAL_OUTPUT_SCALE_FOR_LOG_COUNTS
+        self.output_dim = 3
+
+        # Values related to logit cell probability
+        self.INITIAL_WEIGHT_FOR_LOG_COUNTS = 2.
+        self.P_OUTPUT_SCALE = 1.
+        self.log_count_crossover = log_count_crossover
+        self.prior_log_cell_counts = prior_log_cell_counts
+
+        # Values related to epsilon
+        self.EPS_OUTPUT_SCALE = 0.05  # slows down learning for epsilon
+        self.EPS_OUTPUT_MEAN = 1.
 
         # Set up the linear transformations used in fully-connected layers.
-        # Adjust initialization conditions to start with a reasonable output.
-        self.linears = nn.ModuleList([nn.Linear(1 + 2*input_dim,
+
+        self.linears = nn.ModuleList([nn.Linear(3 + self.n_genes,
                                                 hidden_dims[0])])
-        with torch.no_grad():
-            self.linears[-1].weight[0][0] = self.INITIAL_WEIGHT_FOR_LOG_COUNTS
         for i in range(1, len(hidden_dims)):  # Second hidden layer onward
             self.linears.append(nn.Linear(hidden_dims[i-1], hidden_dims[i]))
-            # Initialize p so that it starts out based (almost) on UMI counts.
-            with torch.no_grad():
-                self.linears[-1].weight[0][0] = self.INITIAL_WEIGHT_FOR_LOG_COUNTS
-        self.output = nn.Linear(hidden_dims[-1], output_dim)
-        # Initialize p to be a sigmoid function of UMI counts.
-        with torch.no_grad():
-            self.output.weight[0][0] = self.INITIAL_OUTPUT_SCALE_FOR_LOG_COUNTS
-            self.output.bias.data.copy_(torch.tensor([self.INITIAL_OUTPUT_BIAS_FOR_LOG_COUNTS
-                                                      * log_count_crossover]))
+        self.output = nn.Linear(hidden_dims[-1], self.output_dim)
+
+        # Adjust initialization conditions to start with a reasonable output.
+        self._weight_init()
 
         # Set up the non-linear activations.
+        self.nonlin = nn.Softplus()
         self.softplus = nn.Softplus()
+
+        # Set up the initial biases.
+        self.offset = None
+
+        # Set up the initial scaling for values of x.
+        self.x_scaling = None
+
+        # Set up initial values for overlap normalization.
+        self.overlap_mean = None
+        self.overlap_std = None
+
+    def _weight_init(self):
+        """Initialize neural network weights"""
+
+        # Initialize p to be a sigmoid function of UMI counts.
+        for linear in self.linears:
+            with torch.no_grad():
+                linear.weight[0][0] = 1.
+        with torch.no_grad():
+            self.output.weight[0][0] = self.INITIAL_WEIGHT_FOR_LOG_COUNTS
+            # Prevent a negative weight from starting something inverted.
+            self.output.weight[1][0] = torch.abs(self.output.weight[1][0])
+            self.output.weight[2][0] = torch.abs(self.output.weight[2][0])
+
+    def _poisson_log_prob(self, lam, value):
+        return (lam.log() * value) - lam - (value + 1).lgamma()
 
     def forward(self,
                 x: torch.Tensor,
-                chi_ambient: torch.Tensor) -> torch.Tensor:
+                chi_ambient: Optional[torch.Tensor],
+                z: torch.Tensor,
+                **kwargs) -> Dict[str, torch.Tensor]:
         # Define the forward computation to go from gene expression to cell
         # probabilities.  The log of the total UMI counts is concatenated with
         # the input gene expression and the estimate of the difference between
         # the ambient RNA profile and this barcode's gene expression to form
         # an augmented input.
 
-        # Transform input and calculate log total UMI counts per barcode.
-        x = x.reshape(-1, self.input_dim)
-        log_sum = x.sum(dim=-1, keepdim=True).log1p()
+        x = x.reshape(-1, self.n_genes)
+
+        # Calculate log total UMI counts per barcode.
+        counts = x.sum(dim=-1, keepdim=True)
+        log_sum = counts.log1p()
+
+        # Calculate the log of the number of nonzero genes.
+        log_nnz = (x > 0).sum(dim=-1, keepdim=True).float().log1p()
+
+        # Calculate a similarity between expression and ambient.
+        if chi_ambient is not None:
+            overlap = self._poisson_log_prob(lam=counts * chi_ambient.detach().unsqueeze(0),
+                                             value=x).sum(dim=-1, keepdim=True)
+            if self.overlap_mean is None:
+                self.overlap_mean = (overlap.max() + overlap.min()) / 2
+                self.overlap_std = overlap.max() - overlap.min()
+            overlap = (overlap - self.overlap_mean) / self.overlap_std * 5
+        else:
+            overlap = torch.zeros_like(counts)
+
+        # Apply transformation to data.
         x = transform_input(x, self.transform)
+
+        # Calculate a scale factor (first time through) to control the input variance.
+        if self.x_scaling is None:
+            n_std_est = 10
+            num = int(self.n_genes * 0.4)
+            std_estimates = torch.zeros([n_std_est])
+            for i in range(n_std_est):
+                idx = torch.randperm(x.nelement())
+                std_estimates[i] = x.view(-1)[idx][:num].std().item()
+            robust_std = std_estimates.median().item()
+            self.x_scaling = (1. / robust_std) / 100.  # Get values on a level field
 
         # Form a new input by concatenation.
         # Compute the hidden layers and the output.
-        hidden = self.softplus(self.linears[0](torch.cat((log_sum,
-                                                          x,
-                                                          x - chi_ambient),
-                                                         dim=-1)))
+        x_in = torch.cat((log_sum,
+                          log_nnz,
+                          overlap,
+                          x * self.x_scaling),
+                         dim=-1)
+
+        hidden = self.nonlin(self.linears[0](x_in))
         for i in range(1, len(self.linears)):  # Second hidden layer onward
-            hidden = self.softplus(self.linears[i](hidden))
+            hidden = self.nonlin(self.linears[i](hidden))
 
-        return self.output(hidden).squeeze(-1)
+        out = self.output(hidden).squeeze(-1)
+
+        if self.offset is None:
+
+            self.offset = dict()
+
+            # Heuristic for initialization of logit_cell_probability.
+            cells = (log_sum > self.log_count_crossover).squeeze()
+            if (cells.sum() > 0) and ((~cells).sum() > 0):
+                cell_median = out[cells, 0].median().item()
+                empty_median = out[~cells, 0].median().item()
+                self.offset['logit_p'] = empty_median + (cell_median - empty_median) * 9. / 10
+            else:
+                self.offset['logit_p'] = 0.
+
+            # Heuristic for initialization of d.
+            self.offset['d'] = out[cells, 1].median().item()
+
+            # Heuristic for initialization of epsilon.
+            self.offset['epsilon'] = out[cells, 2].mean().item()
+
+        p_y_logit = ((out[:, 0] - self.offset['logit_p'])
+                     * self.P_OUTPUT_SCALE).squeeze()
+        epsilon = self.softplus((out[:, 2] - self.offset['epsilon']).squeeze()
+                                * self.EPS_OUTPUT_SCALE + self.EPS_OUTPUT_MEAN)
+
+        return {'p_y': p_y_logit,
+                'd_loc': self.softplus(out[:, 1] - self.offset['d']
+                                       + self.softplus(log_sum.squeeze()
+                                                       - self.log_count_crossover)
+                                       + self.log_count_crossover).squeeze(),
+                'epsilon': epsilon}
 
 
-def transform_input(x: torch.Tensor, transform: str) -> Union[torch.Tensor,
-                                                              None]:
+def transform_input(x: torch.Tensor, transform: str) -> torch.Tensor:
     """Transform input to encoder.
 
     Args:
@@ -309,6 +352,5 @@ def transform_input(x: torch.Tensor, transform: str) -> Union[torch.Tensor,
         return x
 
     else:
-        warnings.warn("Specified an input transform that is not "
-                      "supported.  Choose from 'log' or 'normalize'.")
-        return None
+        raise NotImplementedError("Specified an input transform that is not "
+                                  "supported.  Choose from 'log' or 'normalize'.")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,16 +12,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     bzip2 \
  && sudo rm -rf /var/lib/apt/lists/* \
- && curl -so ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh \
+ && curl -so ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x ~/miniconda.sh \
- && ~/miniconda.sh -b -p ~/miniconda \
- && rm ~/miniconda.sh \
- && ~/miniconda/bin/conda install -y pytorch torchvision cudatoolkit=9.2 -c pytorch \
- && ~/miniconda/bin/conda install -y -c anaconda pytables \
- && ~/miniconda/bin/conda clean -ya \
- && git clone https://github.com/broadinstitute/CellBender.git cellbender \
- && yes | ~/miniconda/bin/pip install -e cellbender \
+ && ~/miniconda.sh -b -p /home/user/miniconda \
+ && rm ~/miniconda.sh
+
+ENV PATH=/home/user/miniconda/bin:$PATH
+ENV CONDA_AUTO_UPDATE_CONDA=false
+
+RUN conda install -y pytorch torchvision cudatoolkit=9.2 -c pytorch \
+ && conda install -y -c anaconda pytables \
+ && conda clean -ya
+
+ENV DOCKER='true'
+
+RUN git clone https://github.com/broadinstitute/CellBender.git cellbender \
+ && yes | pip install -e cellbender \
  && sudo rm -rf ~/.cache/pip
+
+# google cloud SDK and gsutil
+RUN curl -sSL https://sdk.cloud.google.com | bash
+RUN conda install -y -c conda-forge google-api-python-client oauth2client google-auth \
+ google-cloud-sdk google-auth-oauthlib \
+ && conda clean -ya
 
 # Add cellbender command to PATH
 ENV PATH="~/miniconda/bin:${PATH}"

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -1,0 +1,15 @@
+# https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
+
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,8 @@ extensions = [
     'sphinx.ext.intersphinx'
 ]
 
+master_doc = 'index'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -62,4 +64,8 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 html_favicon = '_static/design/favicon.ico'
-
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }

--- a/docs/source/getting_started/remove_background/index.rst
+++ b/docs/source/getting_started/remove_background/index.rst
@@ -7,9 +7,9 @@ In this tutorial, we will run ``remove-background`` on a small dataset derived f
 ``pbmc4k`` scRNA-seq dataset (v2 Chemistry, CellRanger 2.1.0).
 
 As a first step, we download the full dataset and generate a smaller `trimmed` copy by selecting 500 barcodes
-with high UMI count (likely non-empty) and an additional 50'000 barcodes with small UMI count (likely empty). Note
+with high UMI count (likely non-empty) and an additional 50,000 barcodes with small UMI count (likely empty). Note
 that the trimming step is performed in order to allow us go through this tutorial in a matter of minutes on a
-typical personal computer. Processing the full untrimmed dataset requires a CUDA-enabled GPU (e.g. NVIDIA Testla K80)
+typical CPU. Processing the full untrimmed dataset requires a CUDA-enabled GPU (e.g. NVIDIA Testla K80)
 and takes about 30 minutes to finish.
 
 We have created a python script to download and trim the dataset. Navigate to ``examples/remove_background/``
@@ -34,6 +34,9 @@ We proceed to run ``remove-background`` on the trimmed dataset using the followi
         --output ./tiny_10x_pbmc.h5 \
         --expected-cells 500 \
         --total-droplets-included 5000
+
+Again, here we leave out the ``--cuda`` flag solely for the purposes of being able to run this
+command on a CPU.  But a GPU is highly recommended for real datasets.
 
 The computation will finish within a minute or two (after ~ 150 epochs). The tool outputs the following files:
 

--- a/docs/source/help_and_reference/remove_background/index.rst
+++ b/docs/source/help_and_reference/remove_background/index.rst
@@ -31,6 +31,11 @@ input options, which are described in detail
 Troubleshooting
 ---------------
 
+* The learning curve in the output PDF has large downward spikes, or looks super wobbly.
+
+  * This could indicate instabilities during training that should be addressed. The solution
+    is typically to reduce the ``--learning-rate`` by a factor of two.
+
 * The following warning is emitted in the log file: "Warning: few empty droplets identified.
   Low UMI cutoff may be too high. Check the UMI decay curve, and decrease the
   ``--low-count-threshold`` parameter if necessary."
@@ -61,7 +66,7 @@ Troubleshooting
 
   * Try estimating ``--expected-cells`` from the UMI curve rather than a priori, and
     increase the number if necessary.
-  * Experiment with increasing ``--total-droplets-included``.
+  * Experiment with increasing or decreasing ``--total-droplets-included``.
 
 
 * The PCA plot of latent gene expression shows no clusters or structure.
@@ -72,17 +77,5 @@ Troubleshooting
   * This is not necessarily a bad thing, although it indicates that cells in the experiment
     had a continuum of expression, or that there was only one cell type.  If this is
     known to be false, some sort of QC failure with the experiment would be suspected.
-    Perform a downstream clustering analysis to see if the results are the same.
-
-
-* During downstream analysis, it seems there has been too much imputation.  I am seeing
-  genes expressed in clusters where they were not expressed before.
-
-  * You should not see genes expressed where they were not expressed before.
-    ``remove-background`` does involve some amount of imputation, since we are inferring the
-    true, background-removed counts in the context of our probabilistic model.  Gene expression
-    is modeled using an autoencoder.  The amount of imputation can be minimized by
-    maximizing the capacity of this autoencoder.  The default dimension of the latent space,
-    ``--z-dim``, is 20.  The default dimension of the hidden layer in the autoencoder,
-    ``--z-layers``, is 500.  Try setting ``--z-dim`` to 200 and ``--z-layers`` to 1000.
-    This will minimize imputation.
+    Perform a downstream clustering analysis with and without ``cellbender remove-background``
+    and compare the two.

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -41,6 +41,10 @@ A GPU-enabled docker image is available from the Google Container Registry (GCR)
 
 ``us.gcr.io/broad-dsde-methods/cellbender:latest``
 
+Older versions are available at the same location, for example as
+
+``us.gcr.io/broad-dsde-methods/cellbender:0.1.0``
+
 
 Terra Workflow
 --------------

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ def readme():
 def get_requirements_filename():
     if 'READTHEDOCS' in os.environ:
         return "REQUIREMENTS-RTD.txt"
+    elif 'DOCKER' in os.environ:
+        return "REQUIREMENTS-DOCKER.txt"
     else:
         return "REQUIREMENTS.txt"
 

--- a/wdl/cellbender_remove_background.wdl
+++ b/wdl/cellbender_remove_background.wdl
@@ -1,4 +1,4 @@
-## Copyright Broad Institute, 2019
+## Copyright Broad Institute, 2020
 ##
 ## LICENSING :
 ## This script is released under the WDL source code license (BSD-3)
@@ -10,6 +10,9 @@ task run_cellbender_remove_background_gpu {
   String sample_name
   File input_10x_h5_file_or_mtx_directory
 
+  # Outputs
+  String output_directory  # Google bucket path
+
   # Docker image for cellbender remove-background version
   String? docker_image = "us.gcr.io/broad-dsde-methods/cellbender:latest"
 
@@ -18,11 +21,10 @@ task run_cellbender_remove_background_gpu {
   Int? total_droplets_included
   String? model
   Int? low_count_threshold
+  String? fpr  # in quotes: floats separated by whitespace: the output false positive rate(s)
   Int? epochs
   Int? z_dim
   String? z_layers  # in quotes: integers separated by whitespace
-  String? d_layers  # in quotes: integers separated by whitespace
-  String? p_layers  # in quotes: integers separated by whitespace
   Float? empty_drop_training_fraction
   String? blacklist_genes  # in quotes: integers separated by whitespace
   Float? learning_rate
@@ -30,7 +32,10 @@ task run_cellbender_remove_background_gpu {
   # Hardware-related inputs
   String? hardware_zones = "us-east1-d us-east1-c us-central1-a us-central1-c us-west1-b"
   Int? hardware_disk_size_GB = 50
+  Int? hardware_boot_disk_size_GB = 20
   Int? hardware_preemptible_tries = 2
+  Int? hardware_cpu_count = 4
+  Int? hardware_memory_GB = 15
 
   command {
     cellbender remove-background \
@@ -39,32 +44,33 @@ task run_cellbender_remove_background_gpu {
       --cuda \
       ${"--expected-cells " + expected_cells} \
       ${"--total-droplets-included " + total_droplets_included} \
+      ${"--fpr " + fpr} \
       ${"--model " + model} \
       ${"--low-count-threshold " + low_count_threshold} \
       ${"--epochs " + epochs} \
       ${"--z-dim " + z_dim} \
       ${"--z-layers " + z_layers} \
-      ${"--d-layers " + d_layers} \
-      ${"--p-layers " + p_layers} \
       ${"--empty-drop-training-fraction " + empty_drop_training_fraction} \
       ${"--blacklist-genes " + blacklist_genes} \
       ${"--learning-rate " + learning_rate}
+
+    gsutil -m cp ${sample_name}_out* ${output_directory}/${sample_name}/
   }
 
   output {
     File log = "${sample_name}_out.log"
     File pdf = "${sample_name}_out.pdf"
     File csv = "${sample_name}_out_cell_barcodes.csv"
-    File h5 = "${sample_name}_out.h5"
-    File h5_filt = "${sample_name}_out_filtered.h5"
+    Array[File] h5_array = glob("${sample_name}_out*.h5")  # v2 creates a number of outputs depending on "fpr"
+    String output_dir = "${output_directory}/${sample_name}"
   }
 
   runtime {
     docker: "${docker_image}"
-    bootDiskSizeGb: 20
+    bootDiskSizeGb: hardware_boot_disk_size_GB
     disks: "local-disk ${hardware_disk_size_GB} HDD"
-    memory: "15G"
-    cpu: 4
+    memory: "${hardware_memory_GB}G"
+    cpu: hardware_cpu_count
     zones: "${hardware_zones}"
     gpuCount: 1
     gpuType: "nvidia-tesla-k80"
@@ -82,8 +88,8 @@ workflow cellbender_remove_background {
     File log = run_cellbender_remove_background_gpu.log
     File pdf = run_cellbender_remove_background_gpu.pdf
     File csv = run_cellbender_remove_background_gpu.csv
-    File h5 = run_cellbender_remove_background_gpu.h5
-    File h5_filt = run_cellbender_remove_background_gpu.h5_filt
+    Array[File] h5_array = run_cellbender_remove_background_gpu.h5_array
+    String output_directory = run_cellbender_remove_background_gpu.output_dir
   }
 
 }


### PR DESCRIPTION
An intermediate step on our way to more-finalized code which will be published in an upcoming paper, this PR represents a large change for `remove-background`, and this version is actively being used in many ongoing research projects.

Major changes from `v0.1.0`:
- The model has been modified so that cell counts are drawn from a negative binomial and noise counts are Poisson-distributed. Observed count data is then explicitly the sum of cell counts and noise counts.
- The output count matrix is constructed by posterior sampling the real cell counts (which are marginalized over during training).  This guarantees that the output counts are strictly less than the input counts for each entry in the count matrix.
- A new parameter `--fpr` now controls the tradeoff between signal and noise that is implicit in any noise-removal procedure. Posterior regularization is used to generate an output count matrix that targets this "false positive rate" specified by the user.  A "false positive" in this context is a real cell count that is erroneously removed.  FPR of 0.01 means that the tool will remove as much noise as possible while controlling the removal of real signal to be no more than 1% in expectation.

Many other implementation details have been modified as well.
