### PR TITLE
Fix computation of when learning should be retried with lower learning rate.

### DIFF
--- a/REQUIREMENTS-DOCKER.txt
+++ b/REQUIREMENTS-DOCKER.txt
@@ -4,6 +4,6 @@ scipy
 tables
 pandas
 pyro-ppl>=0.3.2
-torch
+torch>=1.9.0
 scikit-learn
 matplotlib

--- a/cellbender/remove_background/argparse.py
+++ b/cellbender/remove_background/argparse.py
@@ -139,11 +139,11 @@ def add_subparser_args(subparsers: argparse) -> argparse:
                                 "do not exceed 1e-3). (default: %(default)s)")
     subparser.add_argument("--final-elbo-fail-fraction", type=float,
                            help="Training is considered to have failed if "
-                                "final_training_ELBO >= best_training_ELBO*(1+FINAL_ELBO_FAIL_FRACTION). "
+                                "(best_test_ELBO - final_test_ELBO)/(best_test_DLBO - initial_train_ELBO) > FINAL_ELBO_FAIL_FRACTION."
                                 "(default: do not fail training based on final_training_ELBO)")
     subparser.add_argument("--epoch-elbo-fail-fraction", type=float,
                            help="Training is considered to have failed if "
-                                "current_epoch_training_ELBO >= previous_epoch_training_ELBO*(1+EPOCH_ELBO_FAIL_FRACTION). "
+                                "(previous_epoch_test_ELBO - current_epoch_test_ELBO)/(previous_epoch_test_ELBO - initial_train_ELBO) > EPOCH_ELBO_FAIL_FRACTION."
                                 "(default: do not fail training based on epoch_training_ELBO)")
     subparser.add_argument("--num-training-tries", type=int, default=1,
                            help="Number of times to attempt to train the model.  Each subsequent "

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PATH=/home/user/miniconda/bin:$PATH
 ENV CONDA_AUTO_UPDATE_CONDA=false
 
-RUN conda install -y pytorch torchvision cudatoolkit -c pytorch \
+RUN conda install -y "pytorch>=1.9.0" torchvision cudatoolkit -c pytorch \
  && conda install -y -c anaconda pytables \
  && conda clean -ya
 


### PR DESCRIPTION
Hi @sjfleming ,

The code I added to implement --final-elbo-fail-fraction and --epoch-elbo-fail-fraction didn't really make sense before.  Now the percentage change is computed by comparing to (best_test_ELBO - first_train_ELBO) and (previous_test_ELBO - first_train_ELBO), respectively.  Basically, is there a big percentage change relative to the range of the ELBO plot.

In addition, I believe because miniconda is now python 3.8, I needed to add a version requirement for pytorch in order to not get an error.

Regards, Alec