### PR TITLE
Bump version in setup.py to match latest release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
 
 setuptools.setup(
     name='cellbender',
-    version='0.2.0',
+    version='0.2.2',
     description='A software package for eliminating technical artifacts from '
                 'high-throughput single-cell RNA sequencing (scRNA-seq) data',
     long_description=readme(),


### PR DESCRIPTION
Latest releases (>0.2.0) haven't update the version on the package inside setup.py. 
Thus, when checking the installed package version (ie: `pip show cellbender`) people still see `0.2.0` even when the release `0.2.2` has installed.