### PR TITLE
Change scheduler in remove-background/run.py

### DIFF
--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -765,7 +765,7 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
                           'steps_per_epoch': minibatches_per_epoch,
                           'epochs': total_epochs,
                           'optim_args': optimizer_args}
-        scheduler = pyro.optim.OneCycleLR(scheduler_args)
+        scheduler = pyro.optim.lr_scheduler.PyroLRScheduler(scheduler_constructor=torch.optim.lr_scheduler.OneCycleLR, optim_args=scheduler_args)
         if args.constant_learning_rate:
             logger.info('Using ClippedAdam --constant-learning-rate rather than '
                         'the OneCycleLR schedule. This is not usually recommended.')


### PR DESCRIPTION
I was interested in multi-threading, so I installed the most recently edited branch of `cellbender`. Running it with multi-threading didn't work due to an `AttributeError`, as `OneCycleLR` is not in `pyro.optim` (I guess they moved `OneCycleLR` in pytorch, causing it to be incorrectly supported in `pyro`). I fixed it to the best of my knowledge, but I'm new to these modules and this process in general, so any feedback is appreciated.

remove-background works now with multi-threading, but it has a warning and an error, both from pytorch:

- a warning from pytorch: `UserWarning: Detected call of 'lr_scheduler.step()' before 'optimizer.step()'. In PyTorch 1.1.0 and later, you should call them in the opposite order: 'optimizer.step()' before 'lr_scheduler.step()'.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate`
- an error from pytorch after the 75th epoch: `ValueError: Tried to step 7951 times. The specified number of total steps is 7950`

Again, this is my first time contributing to an open source project, so any feedback is appreciated!