### PR TITLE
Fix prior finding bug and add input arguments to force priors

### DIFF
--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -67,6 +67,16 @@ def add_subparser_args(subparsers: argparse) -> argparse:
                                 "Include the droplets which might contain "
                                 "cells. Droplets beyond TOTAL_DROPLETS_INCLUDED "
                                 "should be 'surely empty' droplets.")
+    subparser.add_argument("--force-cell-umi-prior",
+                           nargs=None, type=float, default=None,
+                           dest="force_cell_umi_prior",
+                           help="Ignore CellBender's heuristic prior estimation, "
+                                "and use this prior for UMI counts in cells.")
+    subparser.add_argument("--force-empty-umi-prior",
+                           nargs=None, type=float, default=None,
+                           dest="force_empty_umi_prior",
+                           help="Ignore CellBender's heuristic prior estimation, "
+                                "and use this prior for UMI counts in empty droplets.")
     subparser.add_argument("--model", nargs=None, type=str,
                            default="full",
                            choices=["naive", "simple", "ambient", "swapping", "full"],

--- a/cellbender/remove_background/consts.py
+++ b/cellbender/remove_background/consts.py
@@ -114,3 +114,8 @@ EXTENDED_REPORT = False
 # Maximum batch size
 MAX_BATCH_SIZE = 256
 SMALLEST_ALLOWED_BATCH = 4  # BatchNorm chokes if there is only 1 cell in last batch
+
+# Guesses during prior estimation
+MAX_TOTAL_DROPLETS_GUESSED = 70000
+MAX_EMPTIES_TO_INCLUDE = 20000
+NUM_EMPTIES_INCREMENT = 20000  # if input expected_cells > heuristic prior total_drops

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -79,6 +79,8 @@ def run_remove_background(args: argparse.Namespace):
             SingleCellRNACountsDataset(input_file=args.input_file,
                                        expected_cell_count=args.expected_cell_count,
                                        total_droplet_barcodes=args.total_droplets,
+                                       force_cell_umi_prior=args.force_cell_umi_prior,
+                                       force_empty_umi_prior=args.force_empty_umi_prior,
                                        fraction_empties=args.fraction_empties,
                                        model_name=args.model,
                                        gene_blacklist=args.blacklisted_genes,


### PR DESCRIPTION
Closes #190 

But also revamps and improves the heuristic prior-finding even more.

Adds the following command-line input arguments:
```console
  --force-cell-umi-prior FORCE_CELL_UMI_PRIOR
                        Ignore CellBender's heuristic prior estimation, and
                        use this prior for UMI counts in cells. (default:
                        None)
  --force-empty-umi-prior FORCE_EMPTY_UMI_PRIOR
                        Ignore CellBender's heuristic prior estimation, and
                        use this prior for UMI counts in empty droplets.
                        (default: None)
```

which will hopefully allow users to handle tricky cases where they just want to override CellBender's heuristics and manually specify the priors themselves.