### PR TITLE
Address MCKP memory issues

### DIFF
--- a/.github/workflows/miniwdl_check.yml
+++ b/.github/workflows/miniwdl_check.yml
@@ -1,0 +1,17 @@
+name: 'Validate all WDLs using miniwdl'
+on: [pull_request]
+env:
+  MINIWDL_VERSION: 1.8.0
+jobs:
+  miniwdl-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+      - name: 'Install miniwdl and Run Validation Test'
+        run: |
+          pip install miniwdl==$MINIWDL_VERSION;
+          ./cellbender/remove_background/tests/miniwdl_check_wdl.sh;
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 *.tsv
 *.csv
 *.npz
+*.tar.gz

--- a/cellbender/remove_background/data/dataprep.py
+++ b/cellbender/remove_background/data/dataprep.py
@@ -173,8 +173,8 @@ class DataLoader:
             return dense_tensor.to(device=self.device)
 
 
-def prep_sparse_data_for_training(dataset: sp.csr.csr_matrix,
-                                  empty_drop_dataset: sp.csr.csr_matrix,
+def prep_sparse_data_for_training(dataset: sp.csr_matrix,
+                                  empty_drop_dataset: sp.csr_matrix,
                                   training_fraction: float = consts.TRAINING_FRACTION,
                                   fraction_empties: float = consts.FRACTION_EMPTIES,
                                   batch_size: int = consts.DEFAULT_BATCH_SIZE,
@@ -252,7 +252,7 @@ def prep_sparse_data_for_training(dataset: sp.csr.csr_matrix,
     return train_loader, test_loader
 
 
-def sparse_collate(batch: List[Tuple[sp.csr.csr_matrix]]) -> torch.Tensor:
+def sparse_collate(batch: List[Tuple[sp.csr_matrix]]) -> torch.Tensor:
     """Load a minibatch of sparse data as a dense torch.Tensor in memory.
 
     Puts each data field into a tensor with leftmost dimension batch size.

--- a/cellbender/remove_background/data/dataset.py
+++ b/cellbender/remove_background/data/dataset.py
@@ -415,7 +415,7 @@ class SingleCellRNACountsDataset:
 
         return {'chi_ambient': chi_ambient, 'chi_bar': chi_bar}
 
-    def get_count_matrix(self) -> sp.csr.csr_matrix:
+    def get_count_matrix(self) -> sp.csr_matrix:
         """Get the count matrix, trimmed if trimming has occurred."""
 
         # if self.is_trimmed:
@@ -430,7 +430,7 @@ class SingleCellRNACountsDataset:
         #     logger.warning("Using full count matrix, without any trimming.  Could be slow.")
         #     return self.data['matrix']
 
-    def get_count_matrix_empties(self) -> sp.csr.csr_matrix:
+    def get_count_matrix_empties(self) -> sp.csr_matrix:
         """Get the count matrix for empty drops, trimmed if possible."""
 
         # if self.is_trimmed_features:
@@ -445,7 +445,7 @@ class SingleCellRNACountsDataset:
         #     logger.error("Trying to get empty count matrix without trimmed data.")
         #     return self.data['matrix']
 
-    def get_count_matrix_all_barcodes(self) -> sp.csr.csr_matrix:
+    def get_count_matrix_all_barcodes(self) -> sp.csr_matrix:
         """Get the count matrix, trimming only genes, not barcodes."""
 
         # if self.is_trimmed_features:

--- a/cellbender/remove_background/data/io.py
+++ b/cellbender/remove_background/data/io.py
@@ -71,7 +71,7 @@ def write_matrix_to_cellranger_h5(
         output_file: str,
         gene_names: np.ndarray,
         barcodes: np.ndarray,
-        count_matrix: sp.csc.csc_matrix,
+        count_matrix: sp.csc_matrix,
         feature_types: Optional[np.ndarray] = None,
         gene_ids: Optional[np.ndarray] = None,
         genomes: Optional[np.ndarray] = None,
@@ -233,7 +233,7 @@ def unravel_dict(pref: str, d: Dict) -> Dict:
 
 
 def load_data(input_file: str)\
-        -> Dict[str, Union[sp.csr.csr_matrix, List[np.ndarray], np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, List[np.ndarray], np.ndarray]]:
     """Load a dataset into the SingleCellRNACountsDataset object from
     the self.input_file"""
 
@@ -344,7 +344,7 @@ def detect_cellranger_version_h5(filename: str) -> int:
 
 
 def get_matrix_from_cellranger_mtx(filedir: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, List[np.ndarray], np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, List[np.ndarray], np.ndarray]]:
     """Load a count matrix from an mtx directory from CellRanger's output.
 
     For CellRanger v2:
@@ -469,7 +469,7 @@ def get_matrix_from_cellranger_mtx(filedir: str) \
 
 
 def get_matrix_from_cellranger_h5(filename: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Load a count matrix from an h5 file from CellRanger's output.
 
     The file needs to be a _raw_gene_bc_matrices_h5.h5 file.  This function
@@ -612,7 +612,7 @@ def get_matrix_from_cellranger_h5(filename: str) \
 
 
 def get_matrix_from_dropseq_dge(filename: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Load a count matrix from a DropSeq DGE matrix file.
 
     The file needs to be a gzipped text file in DGE format.  This function
@@ -693,7 +693,7 @@ def get_matrix_from_dropseq_dge(filename: str) \
 
 
 def get_matrix_from_bd_rhapsody(filename: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Load a count matrix from a BD Rhapsody MolsPerCell.csv file.
 
     The file needs to be in MolsPerCell_Unfiltered format, which is comma
@@ -775,7 +775,7 @@ def get_matrix_from_bd_rhapsody(filename: str) \
 
 
 def get_matrix_from_npz(filename: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Load a count matrix from a sparse NPZ file, accompanied by barcode and
     gene NPY files.
     NOTE: This format is one output of the Optimus pipeline. It loads much
@@ -827,7 +827,7 @@ def get_matrix_from_npz(filename: str) \
 
 
 def get_matrix_from_anndata(filename: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Load a count matrix from an h5ad AnnData file.
     The file needs to contain raw counts for all measured barcodes in the
     `.X` attribute or a `.layer[{'counts', 'spliced'}]` attribute.  This function
@@ -871,7 +871,7 @@ def get_matrix_from_anndata(filename: str) \
 
 
 def get_matrix_from_loom(filename: str) \
-        -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+        -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Load a count matrix from a loom file.
     The file needs to contain raw counts for all measured barcodes in the
     layer '', as in
@@ -915,7 +915,7 @@ def get_matrix_from_loom(filename: str) \
     return _dict_from_anndata(adata)
 
 
-def _dict_from_anndata(adata: anndata.AnnData) -> Dict[str, Union[sp.csr.csr_matrix, np.ndarray]]:
+def _dict_from_anndata(adata: anndata.AnnData) -> Dict[str, Union[sp.csr_matrix, np.ndarray]]:
     """Extract relevant information from AnnData and format it as a dict
 
     Args:

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -239,6 +239,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
                     n_chunks=n_chunks,
                 )
         ):
+            logger.info(f'Working on chunk ({i + 1}/{n_chunks})')
             chunk_csr = self._chunk_estimate_noise(
                 noise_log_prob_coo=noise_coo_chunk,
                 noise_offsets=noise_offsets,
@@ -334,7 +335,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
         map_csr = self._estimation_array_to_csr(data=map_dict['result'],
                                                 m=map_dict['m'],
                                                 noise_offsets=noise_offsets)
-        logger.info('Computed initial MAP estimate')
+        logger.debug(f'{timestamp()} Computed initial MAP estimate')
         logger.debug(f'{timestamp()} Time for MAP calculation = {(time.time() - t):.2f} sec')
         map_noise_counts_per_gene = np.array(map_csr.sum(axis=0)).squeeze()
         additional_noise_counts_per_gene = (noise_targets_per_gene

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -210,9 +210,8 @@ class MultipleChoiceKnapsack(EstimationMethod):
                        noise_log_prob_coo: sp.coo_matrix,
                        noise_offsets: Dict[int, int],
                        noise_targets_per_gene: np.ndarray,
-                       approx_gb: float = 1.,
                        verbose: bool = False,
-                       min_chunks: Optional[int] = None,  # just for testing
+                       n_chunks: Optional[int] = None,
                        **kwargs) -> sp.csr_matrix:
         """Given the full probabilistic posterior, compute noise counts
 
@@ -221,58 +220,55 @@ class MultipleChoiceKnapsack(EstimationMethod):
                 values in a (m, c) COO matrix
             noise_targets_per_gene: Integer noise count target for each gene
             noise_offsets: Noise count offset values keyed by 'm'.
-            approx_gb: Approximate memory to be used for each gene-wise chunk
-                of this computation. This is baseline, not peak memory. Peak
-                memory might be 12x this value (on top of whatever else is
-                going on)
             verbose: True to print lots of intermediate information (for tests)
-            min_chunks: For tests, to ensure chunking works
+            n_chunks: Target number of chunks over which to split estimation.
+                If None, targets about 1000 genes per chunk.
 
         Returns:
             noise_count_csr: Estimated noise count matrix.
         """
+        if n_chunks is None:
+            n_chunks = self.index_converter.total_n_genes // 1000
+            logger.debug(f'Running MCKP estimator in {n_chunks} chunks')
+
+        t = time.time()
         csr_matrices = []
-        for chunk in self._gene_chunk_iterator(
-            noise_log_prob_coo=noise_log_prob_coo,
-            approx_gb=approx_gb,
-            min_chunks=min_chunks,
+        for i, noise_coo_chunk in enumerate(
+                self._gene_chunk_iterator(
+                    noise_log_prob_coo=noise_log_prob_coo,
+                    n_chunks=n_chunks,
+                )
         ):
-            noise_coo = chunk[0]
-            gene_logic = chunk[1]
             chunk_csr = self._chunk_estimate_noise(
-                noise_log_prob_coo=noise_coo,
+                noise_log_prob_coo=noise_coo_chunk,
                 noise_offsets=noise_offsets,
                 noise_targets_per_gene=noise_targets_per_gene,
                 verbose=verbose,
             )
-            csr_matrices.append(chunk_csr.tocsc()[:, gene_logic].tocsr())
-        return sp.hstack(csr_matrices)
+            logger.debug(f'{timestamp()} Estimator chunk {i}: shape is {chunk_csr.shape}')
+            csr_matrices.append(chunk_csr)
+
+        logger.debug(f'{timestamp()} Total MCKP estimation time = {(time.time() - t):.2f} sec')
+        return sum(csr_matrices)
 
     def _gene_chunk_iterator(self,
                              noise_log_prob_coo: sp.coo_matrix,
-                             approx_gb: float,
-                             min_chunks: Optional[int] = None) \
-            -> Generator[Tuple[sp.coo_matrix, np.ndarray], None, None]:
+                             n_chunks: int) \
+            -> Generator[sp.coo_matrix, None, None]:
         """Yields chunks of the posterior that can be treated as independent,
         from the standpoint of MCKP count estimation.  That is, they contain all
         matrix entries for any genes they include.
 
         Args:
-            approx_gb: Aim to grab a chunk of this size
-            min_chunks: For testing, force this many chunks
+            noise_log_prob_coo: Full noise log prob posterior COO
+            n_chunks: For testing, force this many chunks
 
         Yields:
-            Tuple of (coo posterior, gene_logic) for the chunk
+            coo posterior for the chunk
         """
 
-        def _approx_size(n_entries: int) -> float:
-            approx_size = (n_entries * 3) * 4 / 1e9  # GB, torch float32 is 4 bytes
-            approx_size = approx_size * 20  # empirical fudge from memory profiler
-            return approx_size
-
-        if min_chunks is not None:
-            # reset approx_gb to target the right number of chunks
-            approx_gb = _approx_size((noise_log_prob_coo.data.size - 1) // min_chunks)
+        # approximate number of entries in a chunk
+        approx_chunk_entries = (noise_log_prob_coo.data.size - 1) // n_chunks
 
         # get gene annotations
         _, genes = self.index_converter.get_ng_indices(m_inds=noise_log_prob_coo.row)
@@ -280,7 +276,6 @@ class MultipleChoiceKnapsack(EstimationMethod):
         # things we need to keep track of for each chunk
         current_chunk_genes = []
         entry_logic = np.zeros(noise_log_prob_coo.data.size, dtype=bool)
-        gene_logic = np.zeros(self.index_converter.total_n_genes, dtype=bool)
 
         def _subset_coo(coo: sp.coo_matrix, logic: np.ndarray) -> sp.coo_matrix:
             return sp.coo_matrix((coo.data[logic], (coo.row[logic], coo.col[logic])))
@@ -291,22 +286,20 @@ class MultipleChoiceKnapsack(EstimationMethod):
             # append current gene
             current_chunk_genes.append(g)
             entry_logic = entry_logic | (genes == g)
-            gene_logic[g] = True
 
             # figure out when to send out a chunk
-            if _approx_size(entry_logic.sum()) >= approx_gb:
-                logger.debug('New gene chunk being processed by MCKP')
-                yield _subset_coo(noise_log_prob_coo, entry_logic), gene_logic
+            if entry_logic.sum() >= approx_chunk_entries:
+                logger.debug(f'{timestamp()} New gene chunk being processed by MCKP')
+                yield _subset_coo(noise_log_prob_coo, entry_logic)
 
                 # keep track and reset stuff
                 entry_logic = np.zeros(noise_log_prob_coo.data.size, dtype=bool)
-                gene_logic = np.zeros(self.index_converter.total_n_genes, dtype=bool)
                 current_chunk_genes = []
 
         # last bit
         if entry_logic.sum() > 0:
-            logger.debug('New gene chunk being processed by MCKP')
-            yield _subset_coo(noise_log_prob_coo, entry_logic), gene_logic
+            logger.debug(f'{timestamp()} New gene chunk being processed by MCKP')
+            yield _subset_coo(noise_log_prob_coo, entry_logic)
 
     def _chunk_estimate_noise(self,
                               noise_log_prob_coo: sp.coo_matrix,
@@ -318,7 +311,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
 
         Args:
             noise_log_prob_coo: The noise log prob data structure: log prob
-                values in a (m, c) COO matrix
+                values in a (m, c) COO matrix.  One chunk.
             noise_targets_per_gene: Integer noise count target for each gene
             noise_offsets: Noise count offset values keyed by 'm'.
             verbose: True to print lots of intermediate information (for tests)
@@ -326,11 +319,6 @@ class MultipleChoiceKnapsack(EstimationMethod):
         Returns:
             noise_count_csr: Estimated noise count matrix.
         """
-
-        # TODO: can I split this in chunks of genes and use multiprocessing??
-        # TODO: this runs on one CPU at 100% for quite some time
-        # TODO: the issue seems to be high memory use (runs out on hgmm12k with 52GB RAM)
-        # TODO: do I understand the high memory usage?
 
         assert noise_targets_per_gene.size == self.index_converter.total_n_genes, \
             f'The number of noise count targets ({noise_targets_per_gene.size}) ' \
@@ -347,7 +335,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
                                                 m=map_dict['m'],
                                                 noise_offsets=noise_offsets)
         logger.info('Computed initial MAP estimate')
-        logger.debug(f'Time for MAP calculation = {(time.time() - t) / 60:.2f} mins')
+        logger.debug(f'{timestamp()} Time for MAP calculation = {(time.time() - t):.2f} sec')
         map_noise_counts_per_gene = np.array(map_csr.sum(axis=0)).squeeze()
         additional_noise_counts_per_gene = (noise_targets_per_gene
                                             - map_noise_counts_per_gene).astype(int)
@@ -362,12 +350,12 @@ class MultipleChoiceKnapsack(EstimationMethod):
                                 'g': g,
                                 'c': coo.col,
                                 'log_prob': coo.data})
-        logger.debug('Computing step directions')
+        logger.debug(f'{timestamp()} Computing step directions')
         df['positive_step_gene'] = df['g'].apply(lambda gene: gene in set_positive_genes)
         df['negative_step_gene'] = df['g'].apply(lambda gene: gene in set_negative_genes)
         df['step_direction'] = (df['positive_step_gene'].astype(int)
                                 - df['negative_step_gene'].astype(int))  # -1 or 1
-        logger.debug('Step directions done')
+        logger.debug(f'{timestamp()} Step directions done')
 
         if verbose:
             pd.set_option('display.width', 120)
@@ -378,22 +366,22 @@ class MultipleChoiceKnapsack(EstimationMethod):
         df = df[df['step_direction'] != 0]
 
         # Now we mask out log probs (-np.inf) that represent steps in the wrong direction.
-        logger.debug('Masking')
+        logger.debug(f'{timestamp()} Masking')
         lookup_map_from_m = dict(zip(map_dict['m'], map_dict['result']))
         df['map'] = df['m'].apply(lambda x: lookup_map_from_m[x])
         df['mask'] = ((df['negative_step_gene'] & (df['c'] > df['map']))
                       | (df['positive_step_gene'] & (df['c'] < df['map'])))  # keep MAP
         df.loc[df['mask'], 'log_prob'] = -np.inf
-        logger.debug('Masking done')
+        logger.debug(f'{timestamp()} Masking done')
 
         # And we remove those entries.
         df = df[~df['mask']]
         df = df[[c for c in df.columns if (c != 'mask')]]
 
         # Sort
-        logger.debug('Sorting')
+        logger.debug(f'{timestamp()} Sorting')
         df = df.sort_values(by=['m', 'c'])
-        logger.debug('Sorting done')
+        logger.debug(f'{timestamp()} Sorting done')
 
         if verbose:
             print(df, end='\n\n')
@@ -402,7 +390,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
         df_positive_steps = df[df['step_direction'] == 1].copy()
         df_negative_steps = df[df['step_direction'] == -1].copy()
 
-        logger.debug('Computing deltas')
+        logger.debug(f'{timestamp()} Computing deltas')
         if len(df_positive_steps > 0):
             df_positive_steps.loc[:, 'delta'] = df_positive_steps['log_prob'].diff(periods=1).apply(np.abs)
             df_positive_steps.loc[df_positive_steps['c'] == df_positive_steps['map'], 'delta'] = np.nan
@@ -410,7 +398,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
             df_negative_steps.loc[:, 'delta'] = df_negative_steps['log_prob'].diff(periods=-1).apply(np.abs)
             df_negative_steps.loc[df_negative_steps['c'] == df_negative_steps['map'], 'delta'] = np.nan
         df = pd.concat([df_positive_steps, df_negative_steps], axis=0)
-        logger.debug('Computing deltas done')
+        logger.debug(f'{timestamp()} Computing deltas done')
 
         if verbose:
             print(df, end='\n\n')
@@ -427,7 +415,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
             return map_csr
 
         # How many additional noise counts ("steps") we will need for each gene.
-        logger.debug('Computing nsmallest')
+        logger.debug(f'{timestamp()} Computing nsmallest')
         df['topk'] = df['g'].apply(lambda gene: abs_additional_noise_counts_per_gene[gene])
 
         if verbose:
@@ -438,7 +426,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
         df_out = df[['m', 'g', 'delta', 'topk']].groupby('g', group_keys=False).apply(
             lambda x: x.nsmallest(x['topk'].iat[0], columns='delta')
         )
-        logger.debug('Computing nsmallest done')
+        logger.debug(f'{timestamp()} Computing nsmallest done')
 
         if verbose:
             print(df_out, end='\n\n')
@@ -449,7 +437,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
 
         # And the number by which to increment noise counts per entry 'm' is
         # now the number of times that each m value appears in this dataframe.
-        logger.debug('Summarizing steps')
+        logger.debug(f'{timestamp()} Summarizing steps')
         vc = df_out['m'].value_counts()
         vc_df = pd.DataFrame(data={'m': vc.index, 'steps': vc.values})
         step_direction_lookup_from_m = dict(zip(df['m'], df['step_direction']))
@@ -458,7 +446,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
         steps_csr = self._estimation_array_to_csr(data=vc_df['counts'],
                                                   m=vc_df['m'],
                                                   noise_offsets=None)
-        logger.debug('Summarizing steps done')
+        logger.debug(f'{timestamp()} Summarizing steps done')
 
         if verbose:
             print(vc_df, end='\n\n')
@@ -613,3 +601,7 @@ def _parallel_pandas_apply(df_grouped: pd.core.groupby.DataFrameGroupBy,
     with mp.Pool(mp.cpu_count()) as p:
         output_list = p.map(fun, group_df_list)
     return np.array(groupby_val), np.array(output_list)
+
+
+def timestamp() -> str:
+    return f'({time.strftime("%H:%M:%S", time.gmtime())})'

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -417,6 +417,21 @@ class Posterior:
         analyzed_bcs_only = True
         count_matrix = self.dataset_obj.get_count_matrix()  # analyzed barcodes
         cell_logic = (self.latents_map['p'] > consts.CELL_PROB_CUTOFF)
+
+        # Raise an error if there are no cells found.
+        if cell_logic.sum() == 0:
+            logger.error(f'ERROR: Found zero droplets with posterior cell '
+                         f'probability > {consts.CELL_PROB_CUTOFF}. Please '
+                         f'check the log for estimated priors on expected cells, '
+                         f'total droplets included, UMI counts per cell, and '
+                         f'UMI counts in empty droplets, and see whether these '
+                         f'values make sense. Consider using additional input '
+                         f'arguments like --expected-cells, '
+                         f'--total-droplets-included, --force-cell-umi-prior, '
+                         f'and --force-empty-umi-prior, to make these values '
+                         f'accurate for your dataset.')
+            raise RuntimeError('Zero cells found!')
+
         dataloader_index_to_analyzed_bc_index = np.where(cell_logic)[0]
         cell_data_loader = DataLoader(
             count_matrix[cell_logic],

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -101,7 +101,7 @@ def load_or_compute_posterior_and_save(dataset_obj: 'SingleCellRNACountsDataset'
     )
     ckpt_posterior = load_from_checkpoint(tarball_name=args.input_checkpoint_tarball,
                                           filebase=args.checkpoint_filename,
-                                          to_load='posterior')
+                                          to_load=['posterior'])
     if os.path.exists(ckpt_posterior.get('posterior_file', 'does_not_exist')):
         # Load posterior if it was saved in the checkpoint.
         posterior.load(file=ckpt_posterior['posterior_file'])

--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -34,7 +34,7 @@ run_notebook_str = lambda file: \
 to_html_str = lambda file, output: \
     f'jupyter nbconvert ' \
     f'--to html ' \
-    f'--no-input ' \
+    f'--TemplateExporter.exclude_input=True ' \
     f'{file}'
 
 
@@ -520,7 +520,10 @@ def assess_learning_curve(adata,
     tracking_trace = windowed_cumsum(adata.uns['learning_curve_train_elbo'][1:]
                                      - adata.uns['learning_curve_train_elbo'][:-1],
                                      n=windowsize)
-    backtracking = (tracking_trace.min() < -50)
+    big_dip = -1 * (adata.uns['learning_curve_train_elbo'][-1]
+                    - adata.uns['learning_curve_train_elbo'][5]) / 10
+    print(big_dip)
+    backtracking = (tracking_trace.min() < big_dip)
     backtracking_ind = np.argmin(tracking_trace) + windowsize
 
     halftest = len(adata.uns['learning_curve_test_elbo']) // 2

--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -34,7 +34,7 @@ run_notebook_str = lambda file: \
 to_html_str = lambda file, output: \
     f'jupyter nbconvert ' \
     f'--to html ' \
-    f'--no-input' \
+    f'--no-input ' \
     f'{file}'
 
 

--- a/cellbender/remove_background/tests/mckp_memory_profiling.py
+++ b/cellbender/remove_background/tests/mckp_memory_profiling.py
@@ -1,0 +1,146 @@
+"""Script to enable memory usage profiling via memory-profiler"""
+
+from cellbender.remove_background.estimation import MultipleChoiceKnapsack
+from cellbender.remove_background.sparse_utils import zero_out_csr_rows
+from cellbender.remove_background.checkpoint import load_from_checkpoint
+from cellbender.remove_background.posterior import Posterior, \
+    compute_mean_target_removal_as_function
+from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset
+from cellbender.remove_background import consts
+
+import scipy.sparse as sp
+import numpy as np
+from memory_profiler import profile
+
+import argparse
+import sys
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser_ = argparse.ArgumentParser(
+        description="Run memory profiling on output count matrix generation. "
+                    "NOTE that you have to decorate "
+                    "MultipleChoiceKnapsack.estimate_noise() with memory_profiler's "
+                    "@profile() decorator manually.",
+    )
+    parser_.add_argument('-f', '--checkpoint-file',
+                         type=str,
+                         required=True,
+                         dest='input_checkpoint_tarball',
+                         help='Saved CellBender checkpoint file ckpt.tar.gz')
+    parser_.add_argument('-i', '--input',
+                         type=str,
+                         required=True,
+                         dest='input_file',
+                         help='Input data file')
+    return parser_
+
+
+def compute_noise_counts(posterior,
+                         fpr: float,
+                         estimator_constructor: 'EstimationMethod',
+                         **kwargs) -> sp.csr_matrix:
+    """Probably the most important method: computation of the clean output count matrix.
+
+    Args:
+        estimator_constructor: A noise count estimator class derived from
+            the EstimationMethod base class, and implementing the
+            .estimate_noise() method, which creates a point estimate of
+            noise. Pass in the constructor, not an object.
+        **kwargs: Keyword arguments for estimator_constructor().estimate_noise()
+
+    Returns:
+        denoised_counts: Denoised output CSC sparse matrix (CSC for saving)
+
+    """
+
+    # Only compute using defaults if the cache is empty.
+    if posterior._noise_count_regularized_posterior_coo is not None:
+        # Priority is taken by a regularized posterior, since presumably
+        # the user computed it for a reason.
+        posterior_coo = posterior._noise_count_regularized_posterior_coo
+    else:
+        # Use exact posterior if a regularized version is not computed.
+        posterior_coo = (posterior._noise_count_posterior_coo
+                         if (posterior._noise_count_posterior_coo is not None)
+                         else posterior.cell_noise_count_posterior_coo())
+
+    # Instantiate Estimator object.
+    estimator = estimator_constructor(index_converter=posterior.index_converter)
+
+    # Compute point estimate of noise in cells.
+    noise_targets = get_noise_targets(posterior=posterior, fpr=fpr)
+    noise_csr = estimator.estimate_noise(
+        estimator=estimator,
+        noise_log_prob_coo=posterior_coo,
+        noise_offsets=posterior._noise_count_posterior_coo_offsets,
+        noise_targets_per_gene=noise_targets,
+        **kwargs,
+    )
+
+    return noise_csr
+
+
+def get_noise_targets(posterior, fpr=0.01):
+    count_matrix = posterior.dataset_obj.data['matrix']  # all barcodes
+    cell_inds = posterior.dataset_obj.analyzed_barcode_inds[posterior.latents_map['p']
+                                                            > consts.CELL_PROB_CUTOFF]
+    non_cell_row_logic = np.array([i not in cell_inds
+                                   for i in range(count_matrix.shape[0])])
+    cell_counts = zero_out_csr_rows(csr=count_matrix, row_logic=non_cell_row_logic)
+
+    noise_target_fun_per_cell = compute_mean_target_removal_as_function(
+        noise_count_posterior_coo=posterior._noise_count_posterior_coo,
+        noise_offsets=posterior._noise_count_posterior_coo_offsets,
+        index_converter=posterior.index_converter,
+        raw_count_csr_for_cells=cell_counts,
+        n_cells=len(cell_inds),
+        device='cpu',
+        per_gene=True,
+    )
+    noise_target_fun = lambda x: noise_target_fun_per_cell(x) * len(cell_inds)
+    noise_targets = noise_target_fun(fpr).detach().cpu().numpy()
+    return noise_targets
+
+
+if __name__ == "__main__":
+
+    # handle input arguments
+    parser = get_parser()
+    args = parser.parse_args(sys.argv[1:])
+
+    # load checkpoint
+    ckpt = load_from_checkpoint(tarball_name=args.input_checkpoint_tarball,
+                                filebase=None,
+                                to_load=['model', 'posterior', 'args'],
+                                force_device='cpu')
+
+    # load dataset
+    dataset_obj = \
+        SingleCellRNACountsDataset(input_file=args.input_file,
+                                   expected_cell_count=ckpt['args'].expected_cell_count,
+                                   total_droplet_barcodes=ckpt['args'].total_droplets,
+                                   fraction_empties=ckpt['args'].fraction_empties,
+                                   model_name=ckpt['args'].model,
+                                   gene_blacklist=ckpt['args'].blacklisted_genes,
+                                   exclude_features=ckpt['args'].exclude_features,
+                                   low_count_threshold=ckpt['args'].low_count_threshold,
+                                   ambient_counts_in_cells_low_limit=ckpt['args'].ambient_counts_in_cells_low_limit,
+                                   fpr=ckpt['args'].fpr)
+
+    # load posterior
+    posterior = Posterior(
+        dataset_obj=dataset_obj,
+        vi_model=ckpt['model'],
+        posterior_batch_size=ckpt['args'].posterior_batch_size,
+        debug=False,
+    )
+    posterior.load(file=ckpt['posterior_file'])
+
+    # run output count matrix generation
+    compute_noise_counts(posterior=posterior,
+                         fpr=0.01,
+                         estimator_constructor=MultipleChoiceKnapsack,
+                         approx_gb=0.1)
+
+    sys.exit(0)

--- a/cellbender/remove_background/tests/miniwdl_check_wdl.sh
+++ b/cellbender/remove_background/tests/miniwdl_check_wdl.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# runs from the root directory of the repo
+
+# find all WDL files
+WDL_FILES=$(find . -type f -name "*.wdl")
+
+for WDL in ${WDL_FILES}; do
+  miniwdl check ${WDL}
+done

--- a/cellbender/remove_background/tests/miniwdl_check_wdl.sh
+++ b/cellbender/remove_background/tests/miniwdl_check_wdl.sh
@@ -5,7 +5,8 @@ set -euxo pipefail
 # runs from the root directory of the repo
 
 # find all WDL files
-WDL_FILES=$(find . -type f -name "*.wdl")
+#WDL_FILES=$(find . -type f -name "*.wdl")
+WDL_FILES=("./wdl/cellbender_remove_background.wdl")
 
 for WDL in ${WDL_FILES}; do
   miniwdl check ${WDL}

--- a/cellbender/remove_background/tests/test_estimation.py
+++ b/cellbender/remove_background/tests/test_estimation.py
@@ -263,7 +263,7 @@ def test_cdf(log_prob_coo):
     np.testing.assert_array_equal(out_per_m, log_prob_coo['cdfs'])
 
 
-@pytest.mark.parametrize('min_chunks', [None, 2], ids=['0chunks', '2chunks'])
+@pytest.mark.parametrize('n_chunks', [1, 2], ids=['1chunk', '2chunks'])
 @pytest.mark.parametrize('n_cells, target, truth, truth_mat',
                          ([1, np.zeros(8), np.array([0, 1, 2, 0, 0, 0, 0, 1]), None],
                           [1, np.ones(8), np.array([0, 1, 2, 1, 1, 1, 1, 1]), None],
@@ -277,7 +277,7 @@ def test_cdf(log_prob_coo):
                               '4_cell_target_0',
                               '4_cell_target_4',
                               '4_cell_target_9'])
-def test_mckp(mckp_log_prob_coo, n_cells, target, truth, truth_mat, min_chunks):
+def test_mckp(mckp_log_prob_coo, n_cells, target, truth, truth_mat, n_chunks):
     """Test the multiple choice knapsack problem estimator"""
 
     offset_dict = mckp_log_prob_coo['offsets']
@@ -295,7 +295,7 @@ def test_mckp(mckp_log_prob_coo, n_cells, target, truth, truth_mat, min_chunks):
         noise_offsets=offset_dict,
         noise_targets_per_gene=target,
         verbose=True,
-        min_chunks=min_chunks,
+        n_chunks=n_chunks,
     )
 
     assert noise_csr.shape == (converter.total_n_cells, converter.total_n_genes)

--- a/cellbender/remove_background/tests/test_estimation.py
+++ b/cellbender/remove_background/tests/test_estimation.py
@@ -98,11 +98,11 @@ def mckp_log_prob_coo(request, log_prob_coo_base) \
         else:
             return v
 
-    def _eliminate_row_zero(coo: sp.coo_matrix) -> sp.coo_matrix:
-        row = coo.row -1
-        shape = list(coo.shape)
+    def _eliminate_row_zero(coo_: sp.coo_matrix) -> sp.coo_matrix:
+        row = coo_.row - 1
+        shape = list(coo_.shape)
         shape[0] = shape[0] - 1
-        return sp.coo_matrix((coo.data, (row, coo.col)), shape=shape)
+        return sp.coo_matrix((coo_.data, (row, coo_.col)), shape=shape)
 
     if request.param == 'exact':
         out = log_prob_coo_base
@@ -263,6 +263,7 @@ def test_cdf(log_prob_coo):
     np.testing.assert_array_equal(out_per_m, log_prob_coo['cdfs'])
 
 
+@pytest.mark.parametrize('min_chunks', [None, 2], ids=['0chunks', '2chunks'])
 @pytest.mark.parametrize('n_cells, target, truth, truth_mat',
                          ([1, np.zeros(8), np.array([0, 1, 2, 0, 0, 0, 0, 1]), None],
                           [1, np.ones(8), np.array([0, 1, 2, 1, 1, 1, 1, 1]), None],
@@ -276,7 +277,7 @@ def test_cdf(log_prob_coo):
                               '4_cell_target_0',
                               '4_cell_target_4',
                               '4_cell_target_9'])
-def test_mckp(mckp_log_prob_coo, n_cells, target, truth, truth_mat):
+def test_mckp(mckp_log_prob_coo, n_cells, target, truth, truth_mat, min_chunks):
     """Test the multiple choice knapsack problem estimator"""
 
     offset_dict = mckp_log_prob_coo['offsets']
@@ -294,7 +295,10 @@ def test_mckp(mckp_log_prob_coo, n_cells, target, truth, truth_mat):
         noise_offsets=offset_dict,
         noise_targets_per_gene=target,
         verbose=True,
+        min_chunks=min_chunks,
     )
+
+    assert noise_csr.shape == (converter.total_n_cells, converter.total_n_genes)
 
     # output
     print('dense noise count estimate')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH="$CONDA_DIR/bin:$GCLOUD_DIR/google-cloud-sdk/bin:$PATH"
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates sudo git \
  && apt-get clean \
  && sudo rm -rf /var/lib/apt/lists/* \
- && curl -so $HOME/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh \
+ && curl -so $HOME/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-x86_64.sh \
  && chmod +x $HOME/miniconda.sh \
  && $HOME/miniconda.sh -b -p $CONDA_DIR \
  && rm $HOME/miniconda.sh

--- a/wdl/cellbender_remove_background.wdl
+++ b/wdl/cellbender_remove_background.wdl
@@ -30,6 +30,8 @@ task run_cellbender_remove_background_gpu {
         # Method configuration inputs
         Int? expected_cells
         Int? total_droplets_included
+        Float? force_cell_umi_prior
+        Float? force_empty_umi_prior
         String? model
         Int? low_count_threshold
         String? fpr  # in quotes: floats separated by whitespace: the output false positive rate(s)
@@ -132,6 +134,8 @@ task run_cellbender_remove_background_gpu {
             ~{"--model " + model} \
             ~{"--low-count-threshold " + low_count_threshold} \
             ~{"--epochs " + epochs} \
+            ~{"--force-cell-umi-prior " + force_cell_umi_prior} \
+            ~{"--force-empty-umi-prior " + force_empty_umi_prior} \
             ~{"--z-dim " + z_dim} \
             ~{"--z-layers " + z_layers} \
             ~{"--empty-drop-training-fraction " + empty_drop_training_fraction} \

--- a/wdl/cellbender_remove_background.wdl
+++ b/wdl/cellbender_remove_background.wdl
@@ -87,6 +87,7 @@ task run_cellbender_remove_background_gpu {
             cd /cromwell_root/CellBender
             git checkout -q ~{dev_git_hash__}
             yes | pip install --no-cache-dir -U -e /cromwell_root/CellBender
+            pip list
             cd /cromwell_root
         fi
 


### PR DESCRIPTION
It has been observed that the MCKP estimator hogs a ton of memory!  In some cases where there is a massive genome, or where we have RNA + ATAC, so a ton of features, we get `MemoryError`s even on a machine with 64GB memory.  This is totally unacceptable.

This introduces a new chunking strategy to perform the MCKP estimation in chunks.  This seems to be no slower than doing the whole thing at once!  So it seems to save memory for free.  It might even be marginally faster, if the chunks are not too small.

Addresses a few minor issues with report and logging as well.