### PR TITLE
Move project to python 3.8

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.8']
 
     steps:
     - name: 'Checkout repo'

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ CellBender can be installed via
 
   $ pip install cellbender
 
-(and we recommend installing in its own ``conda`` environment to prevent
-conflicts with other software).
+(and we recommend installing in its own ``conda`` environment, using python 3.8,
+to prevent conflicts with other software).
 
 CellBender is run as a command-line tool, as in
 
@@ -98,7 +98,7 @@ Create a conda environment and activate it:
 
 .. code-block:: console
 
-  $ conda create -n cellbender python=3.7
+  $ conda create -n cellbender python=3.8
   $ conda activate cellbender
 
 Install the `pytables <https://www.pytables.org>`_ module:

--- a/cellbender/remove_background/tests/benchmarking/cuda_check_inputs.json
+++ b/cellbender/remove_background/tests/benchmarking/cuda_check_inputs.json
@@ -1,4 +1,4 @@
 {
-  "check_pytorch_cuda_status.run_check_pytorch_cuda_status.docker_image": "us.gcr.io/broad-dsde-methods/cellbender:20230414"
+  "check_pytorch_cuda_status.run_check_pytorch_cuda_status.docker_image": "us.gcr.io/broad-dsde-methods/cellbender:20230424"
 }
 

--- a/cellbender/remove_background/tests/benchmarking/docker_image_check_cuda_status.wdl
+++ b/cellbender/remove_background/tests/benchmarking/docker_image_check_cuda_status.wdl
@@ -20,6 +20,8 @@ task run_check_pytorch_cuda_status {
         import torch
         assert torch.cuda.is_available()
         CODE
+
+        cellbender remove-background -h
     }
     runtime {
         docker: "${docker_image}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
  && apt-get clean \
  && sudo rm -rf /var/lib/apt/lists/* \
 # get miniconda
- && curl -so $HOME/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-x86_64.sh \
+ && curl -so $HOME/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh \
  && chmod +x $HOME/miniconda.sh \
  && $HOME/miniconda.sh -b -p $CONDA_DIR \
  && rm $HOME/miniconda.sh \
@@ -30,6 +30,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 # get compiled crcmod for gsutil
  && conda install -y -c conda-forge crcmod \
 # install cellbender and its dependencies
- && yes | pip install /software/cellbender/ \
+ && yes | pip install -e /software/cellbender/ \
  && conda clean -yaf \
  && sudo rm -rf ~/.cache/pip

--- a/docker/DockerfileGit
+++ b/docker/DockerfileGit
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
  && apt-get clean \
  && sudo rm -rf /var/lib/apt/lists/* \
 # get miniconda
- && curl -so $HOME/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-x86_64.sh \
+ && curl -so $HOME/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh \
  && chmod +x $HOME/miniconda.sh \
  && $HOME/miniconda.sh -b -p $CONDA_DIR \
  && rm $HOME/miniconda.sh \

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -26,7 +26,7 @@ packages you may have installed.
 
 .. code-block:: console
 
-  $ conda create -n cellbender python=3.7
+  $ conda create -n cellbender python=3.8
   $ conda activate cellbender
   (cellbender) $ pip install cellbender
 
@@ -38,7 +38,7 @@ Create a conda environment and activate it:
 
 .. code-block:: console
 
-  $ conda create -n cellbender python=3.7
+  $ conda create -n cellbender python=3.8
   $ conda activate cellbender
 
 Install the `pytables <https://www.pytables.org>`_ module:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
       'Development Status :: 4 - Beta',
       'Intended Audience :: Science/Research',
       'License :: OSI Approved :: BSD License',
-      'Programming Language :: Python :: 3.7',
+      'Programming Language :: Python :: 3.8',
       'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
     keywords='scRNA-seq bioinformatics',


### PR DESCRIPTION
Pytorch, among other packages, have moved away from python 3.7.
https://pytorch.org/blog/deprecation-cuda-python-support/

This means python 3.7 will not be workable moving forward, and we need to update `cellbender` to python 3.8 at minimum.