### PR TITLE
Write posterior as h5, and some estimator improvements

### DIFF
--- a/cellbender/remove_background/checkpoint.py
+++ b/cellbender/remove_background/checkpoint.py
@@ -243,7 +243,7 @@ def load_from_checkpoint(filebase: Optional[str],
             logger.debug(f'Looking for files with base name matching {filebase}*')
             if not os.path.exists(filebase + '_model.torch'):
                 logger.info('Workflow hash does not match that of checkpoint.')
-                raise ValueError
+                raise ValueError('Workflow hash does not match that of checkpoint.')
         else:
             filebase = (glob.glob(os.path.join(tmp_dir, '*_model.torch'))[0]
                         .replace('_model.torch', ''))

--- a/cellbender/remove_background/consts.py
+++ b/cellbender/remove_background/consts.py
@@ -24,7 +24,7 @@ CELL_PROB_CUTOFF = 0.5
 
 # Default UMI cutoff. Droplets with UMI less than this will be completely
 # excluded from the analysis.
-LOW_UMI_CUTOFF = 15
+LOW_UMI_CUTOFF = 5
 
 # Default total number of droplets to include in the analysis.
 TOTAL_DROPLET_DEFAULT = 25000

--- a/cellbender/remove_background/data/io.py
+++ b/cellbender/remove_background/data/io.py
@@ -221,6 +221,201 @@ def write_matrix_to_cellranger_h5(
     return True
 
 
+def write_posterior_coo_to_h5(
+        output_file: str,
+        posterior_coo: sp.coo_matrix,
+        noise_count_offsets: Dict[int, int],
+        latents: Dict[str, np.ndarray],
+        feature_inds: np.ndarray,
+        barcode_inds: np.ndarray,
+        regularized_posterior_coo: Optional[sp.coo_matrix] = None,
+        posterior_kwargs: Optional[Dict] = None,
+        regularized_posterior_kwargs: Optional[Dict] = None) -> bool:
+    """Write sparse COO matrix to an HDF5 file, using compression.
+
+    NOTE: COO matrix is indexed by rows 'm' which each map to a unique
+    (cell, feature).  The cell and feature are denoted in the barcode_inds
+    and feature_inds arrays.  The column indices for the COO matrix are the
+    number of noise counts for each entry in count matrix, starting with zero,
+    except these noise count values get added to noise_count_offsets, which is
+    length m.
+
+    Args:
+        output_file: Path to output .h5 file (e.g., 'output.h5').
+        posterior_coo: Posterior to be written to file, in sparse COO [m, c]
+            format.  Rows are 'm'-index, columns are number of noise counts.
+        noise_count_offsets: The number of noise counts at which each 'm' starts.
+            Absence of an 'm'-index from the keys of this dict means that the
+            corresponding 'm'-index starts at 0 noise counts.
+        latents: MAP values of latent variables for each analyzed barcode.
+        barcode_inds: Index of each barcode (row of input count matrix).
+        feature_inds: Index of each feature (column of input count matrix).
+        regularized_posterior_coo: Regularized posterior.
+        posterior_kwargs: Keyword arguments used to generate posterior (for
+            caching)
+        regularized_posterior_kwargs: Keyword arguments used to generate
+            posterior (for caching)
+
+    """
+
+    assert isinstance(posterior_coo, sp.coo_matrix), \
+        "The posterior must be coo_matrix format in order to write to HDF5."
+
+    assert barcode_inds.size == posterior_coo.row.size, \
+        "len(barcode_inds) must match the number of entries in the posterior COO"
+
+    assert feature_inds.size == posterior_coo.row.size, \
+        "len(feature_inds) must match the number of entries in the posterior COO"
+
+    # Write to output file.
+    filters = tables.Filters(complevel=1, complib='zlib', shuffle=True)
+    with tables.open_file(
+            output_file,
+            "w",
+            title="CellBender remove-background posterior noise count probabilities"
+    ) as f:
+
+        # metadata
+        extras = f.create_group("/", "metadata", "Posterior metadata")
+        f.create_carray(extras, "barcode_inds", obj=barcode_inds, filters=filters)
+        f.create_carray(extras, "feature_inds", obj=feature_inds, filters=filters)
+        f.create_carray(extras, "noise_count_offsets_keys",
+                        obj=list(noise_count_offsets.keys()), filters=filters)
+        f.create_carray(extras, "noise_count_offsets_values",
+                        obj=list(noise_count_offsets.values()), filters=filters)
+
+        # posterior COO
+        group = f.create_group("/", "posterior_noise_log_prob", "Posterior noise count log probabilities")
+        f.create_carray(group, "log_prob", obj=posterior_coo.data, filters=filters)
+        f.create_carray(group, "m_index", obj=posterior_coo.row, filters=filters)
+        f.create_carray(group, "noise_count", obj=posterior_coo.col, filters=filters)
+        f.create_carray(group, "shape", atom=tables.Int32Atom(),
+                        obj=np.array(posterior_coo.shape, dtype=np.int32), filters=filters)
+
+        # regularized posterior COO
+        if regularized_posterior_coo is not None:
+            group = f.create_group("/", "regularized_posterior_noise_log_prob",
+                                   "Regularized posterior noise count log probabilities")
+            f.create_carray(group, "log_prob", obj=regularized_posterior_coo.data, filters=filters)
+            f.create_carray(group, "m_index", obj=regularized_posterior_coo.row, filters=filters)
+            f.create_carray(group, "noise_count", obj=regularized_posterior_coo.col, filters=filters)
+            f.create_carray(group, "shape", atom=tables.Int32Atom(),
+                            obj=np.array(regularized_posterior_coo.shape, dtype=np.int32), filters=filters)
+
+        # latents
+        droplet_latent_group = f.create_group("/", "droplet_latents_map", "Latent variables per droplet")
+        for key, value in latents.items():
+            if value is not None:
+                f.create_carray(droplet_latent_group, key, obj=value, filters=filters)
+
+        # kwargs
+        if posterior_kwargs is not None:
+            kwargs_group = f.create_group("/", "kwargs", "Function arguments for posterior")
+            for key, value in posterior_kwargs.items():
+                for k, v in unravel_dict(key, value).items():
+                    if type(v) == str:
+                        v = np.array([v], dtype=str)
+                    f.create_array(kwargs_group, k, v)
+            reg_kwargs_group = f.create_group("/", "kwargs_regularized",
+                                              "Function arguments for regularized posterior")
+        if regularized_posterior_kwargs is not None:
+            for key, value in regularized_posterior_kwargs.items():
+                for k, v in unravel_dict(key, value).items():
+                    if type(v) == str:
+                        v = np.array([v], dtype=str)
+                    f.create_array(reg_kwargs_group, k, v)
+
+    logger.info(f"Succeeded in writing posterior to file {output_file}")
+
+    return True
+
+
+def load_posterior_from_h5(filename: str) -> Dict[str, Union[sp.coo_matrix, np.ndarray]]:
+    """Load a posterior noise count COO from an h5 file.
+
+    Args:
+        filename: string path to .h5 file that contains the raw gene
+            barcode matrices
+
+    Returns:
+        Dict with ['coo', 'noise_count_offsets', 'barcode_inds', 'feature_inds']
+            Posterior noise count COO
+            Noise count offsets for COO rows
+            Droplet indices for COO rows
+            Feature indices for COO rows
+    """
+
+    with tables.open_file(filename, 'r') as f:
+
+        # read metadata
+        barcode_inds = getattr(f.root.metadata, 'barcode_inds').read()
+        feature_inds = getattr(f.root.metadata, 'barcode_inds').read()
+        noise_count_offsets_keys = getattr(f.root.metadata, 'noise_count_offsets_keys').read()
+        noise_count_offsets_values = getattr(f.root.metadata, 'noise_count_offsets_values').read()
+        noise_count_offsets = dict(zip(noise_count_offsets_keys, noise_count_offsets_values))
+
+        def _read_coo(group: tables.Group) -> sp.coo_matrix:
+            data = getattr(group, 'log_prob').read()
+            row = getattr(group, 'm_index').read()
+            col = getattr(group, 'noise_count').read()
+            shape = getattr(group, 'shape').read()
+            return sp.coo_matrix((data, (row, col)), shape=shape)
+
+        # read coo
+        posterior_coo = _read_coo(group=f.root.posterior_noise_log_prob)
+
+        # read regularized coo
+        if hasattr(f.root, 'regularized_posterior_noise_log_prob'):
+            regularized_posterior_coo = _read_coo(group=f.root.regularized_posterior_noise_log_prob)
+        else:
+            regularized_posterior_coo = None
+
+        def _read_as_dict(group: tables.Group) -> Dict:
+            d = {}
+            for n in group._f_walknodes('Leaf'):
+                print('entered loop')
+                val = n.read()
+                print(val)
+                if (type(val) == np.ndarray) and ('S' in val.dtype.kind):
+                    print('here')
+                    val = val.item().decode()
+                d.update({n.name: val})
+            return d
+
+        # read latents
+        latents = _read_as_dict(group=f.root.droplet_latents_map)
+
+        # read kwargs
+        if hasattr(f.root, 'kwargs'):
+            kwargs = _read_as_dict(group=f.root.kwargs)
+        else:
+            kwargs = None
+
+        if hasattr(f.root, 'kwargs_regularized'):
+            kwargs_regularized = _read_as_dict(group=f.root.kwargs_regularized)
+        else:
+            kwargs_regularized = None
+
+    # Issue warnings if necessary, based on dimensions matching.
+    if posterior_coo.row.size != barcode_inds.size:
+        logger.warning(f"Number of barcode_inds ({barcode_inds.size}) "
+                       f"in {filename} does not match the number expected from "
+                       f"the sparse COO matrix ({posterior_coo.shape[0]}).")
+    if posterior_coo.row.size != feature_inds.size:
+        logger.warning(f"Number of feature_inds ({feature_inds.size}) "
+                       f"in {filename} does not match the number expected from "
+                       f"the sparse COO matrix ({posterior_coo.shape[0]}).")
+
+    return {'coo': posterior_coo,
+            'kwargs': kwargs,
+            'regularized_coo': regularized_posterior_coo,
+            'kwargs_regularized': kwargs_regularized,
+            'latents': latents,
+            'noise_count_offsets': noise_count_offsets,
+            'feature_inds': feature_inds,
+            'barcode_inds': barcode_inds}
+
+
 def unravel_dict(pref: str, d: Dict) -> Dict:
     """Unravel a nested dict, returning a dict with values that are not dicts"""
 

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -831,6 +831,9 @@ def apply_function_dense_chunks(noise_log_prob_coo: sp.coo_matrix,
 
     for coo, row, col in chunked_iterator(coo=noise_log_prob_coo):
         dense_tensor = torch.tensor(log_prob_sparse_to_dense(coo)).to(device)
+        if torch.numel(dense_tensor) == 0:
+            # github issue 207
+            continue
         s = fun(dense_tensor, **kwargs)
         if s.ndim == 0:
             # avoid "TypeError: len() of a 0-d tensor"

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -139,7 +139,7 @@ class Mean(EstimationMethod):
         # c = torch.arange(noise_log_prob_coo.shape[1], dtype=float).to(device).t()
 
         def _torch_mean(x):
-            c = torch.arange(x.shape[1], dtype=float)
+            c = torch.arange(x.shape[1], dtype=float).to(x.device)
             return torch.matmul(x.exp(), c.t())
 
         result = apply_function_dense_chunks(noise_log_prob_coo=noise_log_prob_coo,

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -237,7 +237,7 @@ def _estimation_array_to_csr(index_converter,
     """
     row, col = index_converter.get_ng_indices(m_inds=m)
     if noise_offsets is not None:
-        data = data + np.array([noise_offsets[i] for i in m])
+        data = data + np.array([noise_offsets.get(i, 0) for i in m])
     coo = sp.coo_matrix((data.astype(dtype), (row.astype(dtype), col.astype(dtype))),
                         shape=index_converter.matrix_shape, dtype=dtype)
     coo.sum_duplicates()

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -102,9 +102,16 @@ def load_or_compute_posterior_and_save(dataset_obj: 'SingleCellRNACountsDataset'
         posterior_batch_size=args.posterior_batch_size,
         debug=args.debug,
     )
-    ckpt_posterior = load_from_checkpoint(tarball_name=args.input_checkpoint_tarball,
-                                          filebase=args.checkpoint_filename,
-                                          to_load=['posterior'])
+    try:
+        ckpt_posterior = load_from_checkpoint(tarball_name=args.input_checkpoint_tarball,
+                                              filebase=args.checkpoint_filename,
+                                              to_load=['posterior'])
+    except ValueError:
+        # input checkpoint tarball was not a match for this workflow
+        # but we still may have saved a new tarball
+        ckpt_posterior = load_from_checkpoint(tarball_name=consts.CHECKPOINT_FILE_NAME,
+                                              filebase=args.checkpoint_filename,
+                                              to_load=['posterior'])
     if os.path.exists(ckpt_posterior.get('posterior_file', 'does_not_exist')):
         # Load posterior if it was saved in the checkpoint.
         posterior.load(file=ckpt_posterior['posterior_file'])

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -17,6 +17,8 @@ from cellbender.remove_background.sparse_utils import dense_to_sparse_op_torch, 
     log_prob_sparse_to_dense, csr_set_rows_to_zero
 from cellbender.remove_background.checkpoint import load_from_checkpoint, \
     unpack_tarball, make_tarball
+from cellbender.remove_background.data.io import \
+    write_posterior_coo_to_h5, load_posterior_from_h5
 
 from typing import Tuple, List, Dict, Optional, Union, Callable
 from abc import ABC, abstractmethod
@@ -161,7 +163,7 @@ class Posterior:
     """
 
     def __init__(self,
-                 dataset_obj: 'SingleCellRNACountsDataset',  # Dataset
+                 dataset_obj: Optional['SingleCellRNACountsDataset'],  # Dataset
                  vi_model: Optional['RemoveBackgroundPyroModel'],
                  posterior_batch_size: int = 128,
                  counts_dtype: np.dtype = np.uint32,
@@ -169,7 +171,8 @@ class Posterior:
                  debug: bool = False):
         self.dataset_obj = dataset_obj
         self.vi_model = vi_model
-        self.vi_model.eval()
+        if vi_model is not None:
+            self.vi_model.eval()
         self.use_cuda = (torch.cuda.is_available() if vi_model is None
                          else vi_model.use_cuda)
         self.device = 'cuda' if self.use_cuda else 'cpu'
@@ -189,29 +192,32 @@ class Posterior:
         self._noise_count_regularized_posterior_coo = None
         self._noise_count_regularized_posterior_kwargs = None
         self._latents = None
-        self.index_converter = IndexConverter(
-            total_n_cells=dataset_obj.data['matrix'].shape[0],
-            total_n_genes=dataset_obj.data['matrix'].shape[1],
-        )
+        if dataset_obj is not None:
+            self.index_converter = IndexConverter(
+                total_n_cells=dataset_obj.data['matrix'].shape[0],
+                total_n_genes=dataset_obj.data['matrix'].shape[1],
+            )
 
     def save(self, file: str, verbose: bool = True) -> bool:
-        """Save the full posterior in compressed array .npz format."""
+        """Save the full posterior in HDF5 format."""
 
         if self._noise_count_posterior_coo is None:
             self.cell_noise_count_posterior_coo()
 
-        d = {'posterior_noise_count_log_prob_coo': self._noise_count_posterior_coo,
-             'posterior_noise_count_coo_offsets': self._noise_count_posterior_coo_offsets,
-             'posterior_kwargs': self._noise_count_posterior_kwargs,
-             'regularized_posterior_noise_count_log_prob_coo': self._noise_count_regularized_posterior_coo,
-             'regularized_posterior_kwargs': self._noise_count_regularized_posterior_kwargs,
-             'latents': self.latents_map}
+        n, g = self.index_converter.get_ng_indices(self._noise_count_posterior_coo.row)
 
-        # TODO: this can choke (out of memory) on very large datasets... not sure why
-        # TODO: is it the compression?  should I save uncompressed and then compress myself?
+        d = {'posterior_coo': self._noise_count_posterior_coo,
+             'noise_count_offsets': self._noise_count_posterior_coo_offsets,
+             'posterior_kwargs': self._noise_count_posterior_kwargs,
+             'regularized_posterior_coo': self._noise_count_regularized_posterior_coo,
+             'regularized_posterior_kwargs': self._noise_count_regularized_posterior_kwargs,
+             'latents': self.latents_map,
+             'feature_inds': g,
+             'barcode_inds': n}
+
         try:
             logger.info(f'Writing full posterior to {file}')
-            np.savez_compressed(file=file, **d)
+            write_posterior_coo_to_h5(output_file=file, **d)
             if verbose:
                 logger.info(f'Saved posterior as {file}')
             return True
@@ -224,13 +230,13 @@ class Posterior:
     def load(self, file: str) -> bool:
         """Load a saved posterior in compressed array .npz format."""
 
-        d = np.load(file=file, allow_pickle=True)
-        self._noise_count_posterior_coo = d['posterior_noise_count_log_prob_coo'].item()
-        self._noise_count_posterior_coo_offsets = d['posterior_noise_count_coo_offsets'].item()
-        self._noise_count_posterior_kwargs = d['posterior_kwargs'].item()
-        self._noise_count_regularized_posterior_coo = d['regularized_posterior_noise_count_log_prob_coo'].item()
-        self._noise_count_regularized_posterior_kwargs = d['regularized_posterior_kwargs'].item()
-        self._latents = d['latents'].item()
+        d = load_posterior_from_h5(filename=file)
+        self._noise_count_posterior_coo = d['coo']
+        self._noise_count_posterior_coo_offsets = d['noise_count_offsets']
+        self._noise_count_posterior_kwargs = d['kwargs']
+        self._noise_count_regularized_posterior_coo = d['regularized_coo']
+        self._noise_count_regularized_posterior_kwargs = d['kwargs_regularized']
+        self._latents = d['latents']
         logger.info(f'Loaded pre-computed posterior from {file}')
         return True
 
@@ -537,7 +543,9 @@ class Posterior:
             (log_probs, (m, c)),
             shape=[np.prod(self.count_matrix_shape), n_counts_max],
         )
-        self._noise_count_posterior_coo_offsets = dict(zip(m, noise_count_offsets))
+        noise_offset_dict = dict(zip(m, noise_count_offsets))
+        nonzero_noise_offset_dict = {k: v for k, v in noise_offset_dict.items() if (v > 0)}
+        self._noise_count_posterior_coo_offsets = nonzero_noise_offset_dict
         return self._noise_count_posterior_coo
 
     @torch.no_grad()
@@ -1084,7 +1092,7 @@ class PRq(PosteriorRegularization):
                               .unsqueeze(0)
                               .expand(log_pdf_noise_counts_BC.shape))
             m_indices_for_chunk = unique_rows[(i * chunk_size):((i + 1) * chunk_size)]
-            noise_count_BC = noise_count_BC + (torch.tensor([noise_offsets[m]
+            noise_count_BC = noise_count_BC + (torch.tensor([noise_offsets.get(m, 0)
                                                              for m in m_indices_for_chunk],
                                                             dtype=torch.float)
                                                .unsqueeze(-1)
@@ -1306,7 +1314,7 @@ class PRmu(PosteriorRegularization):
                               .unsqueeze(0)
                               .expand(log_pdf_noise_counts_BC.shape))
             m_indices_for_chunk = unique_rows[(i * chunk_size):((i + 1) * chunk_size)]
-            noise_count_BC = noise_count_BC + (torch.tensor([noise_offsets[m]
+            noise_count_BC = noise_count_BC + (torch.tensor([noise_offsets.get(m, 0)
                                                              for m in m_indices_for_chunk],
                                                             dtype=torch.float)
                                                .unsqueeze(-1)

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -116,14 +116,14 @@ def load_or_compute_posterior_and_save(dataset_obj: 'SingleCellRNACountsDataset'
         _do_posterior_regularization(posterior)
 
         # Save posterior and add it to checkpoint tarball.
-        saved = posterior.save(file=args.output_file[:-3] + '_posterior.npz')
+        saved = posterior.save(file=args.output_file[:-3] + '_posterior.h5')
         success = False
         if saved:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 unpacked = unpack_tarball(tarball_name=args.input_checkpoint_tarball,
                                           directory=tmp_dir)
                 if unpacked:
-                    posterior.save(file=os.path.join(tmp_dir, 'posterior.npz'), verbose=False)
+                    posterior.save(file=os.path.join(tmp_dir, 'posterior.h5'), verbose=False)
                     all_ckpt_files = [os.path.join(tmp_dir, f) for f in os.listdir(tmp_dir)
                                       if os.path.isfile(os.path.join(tmp_dir, f))]
                     success = make_tarball(files=all_ckpt_files,

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -294,7 +294,7 @@ def compute_output_denoised_counts_reports_metrics(posterior: Posterior,
             index_converter=posterior.index_converter,
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
-            device='cuda' if args.use_cuda else 'cpu',
+            device='cuda' if args.use_cuda else 'cpu',  # TODO check this
             per_gene=True,
         )
         noise_target_fun = lambda x: noise_target_fun_per_cell(x) * len(cell_inds)

--- a/cellbender/remove_background/tests/benchmarking/benchmark.wdl
+++ b/cellbender/remove_background/tests/benchmarking/benchmark.wdl
@@ -11,7 +11,7 @@ import "cellbender_remove_background.wdl" as cellbender
 
 workflow run_cellbender_benchmark {
     input {
-        String git_hash
+        String? git_hash
     }
 
     call cellbender.run_cellbender_remove_background_gpu as cb {

--- a/cellbender/remove_background/tests/benchmarking/benchmark_inputs.json
+++ b/cellbender/remove_background/tests/benchmarking/benchmark_inputs.json
@@ -10,8 +10,10 @@
   "run_cellbender_benchmark.cb.fpr": "FPR",
   "run_cellbender_benchmark.cb.debug": false,
   "run_cellbender_benchmark.cb.checkpoint_mins": 200,
+  "run_cellbender_benchmark.cb.checkpoint_file": null,
   "run_cellbender_benchmark.cb.hardware_preemptible_tries": 0,
   "run_cellbender_benchmark.cb.hardware_cpu_count": 8,
   "run_cellbender_benchmark.cb.hardware_memory_GB": 64,
+  "run_cellbender_benchmark.cb.estimator_multiple_cpu": null,
   "run_cellbender_benchmark.cb.docker_image": "us.gcr.io/broad-dsde-methods/cellbender:0.2.1"
 }

--- a/cellbender/remove_background/tests/benchmarking/run_benchmark.py
+++ b/cellbender/remove_background/tests/benchmarking/run_benchmark.py
@@ -27,10 +27,13 @@ def get_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('-g', '--git',
                         type=str,
-                        required=True,
+                        required=False,
+                        default=None,
                         dest='git_hash',
                         help='Specific github commit from the CellBender repo: '
-                             'can be a tag, a branch, or a commit sha')
+                             'can be a tag, a branch, or a commit sha. Not '
+                             'including the flag will run using the base '
+                             'docker image specified in benchmark_inputs.json')
     parser.add_argument('-i', '--input',
                         type=str,
                         required=True,
@@ -190,7 +193,10 @@ if __name__ == '__main__':
         ))
 
         # run cromshell submit
-        alias = '_'.join(['cellbender', args.sample, args.git_hash])
+        if args.git_hash is not None:
+            alias = '_'.join(['cellbender', args.sample, args.git_hash])
+        else:
+            alias = '_'.join(['cellbender', args.sample])
         workflow_id, alias = cromshell_submit(
             wdl=os.path.join(this_dir, 'benchmark.wdl'),
             inputs=inputs_json,

--- a/cellbender/remove_background/tests/test_checkpoint.py
+++ b/cellbender/remove_background/tests/test_checkpoint.py
@@ -427,8 +427,8 @@ def test_save_and_load_cellbender_checkpoint(tmpdir_factory, cuda, scheduler):
     print('\n'.join([str(t) for t in w1]))
 
     # train in two parts: part 1
-    create_random_state_blank_slate(0)
     pyro.clear_param_store()
+    create_random_state_blank_slate(0)
     args.epochs = epochs
     initial_model, scheduler, train_loader, test_loader = \
         run_inference(dataset_obj=dataset_obj, args=args,

--- a/cellbender/remove_background/tests/test_posterior.py
+++ b/cellbender/remove_background/tests/test_posterior.py
@@ -367,7 +367,8 @@ def test_compute_mean_target_removal_as_function(log_prob_coo, fpr, per_gene, cu
     # TODO: this has not been tested out
 
 
-def test_save_and_load(tmpdir_factory):
+@pytest.mark.parametrize('blank_noise_offsets', [False, True], ids=['', 'no_noise_offsets'])
+def test_save_and_load(tmpdir_factory, blank_noise_offsets):
     """Test that a round trip through save and load gives the same thing"""
 
     tmp_dir = tmpdir_factory.mktemp('posterior')
@@ -380,8 +381,11 @@ def test_save_and_load(tmpdir_factory):
 
     posterior_coo = sp.random(m, n, density=0.1, format='coo', dtype=float)
     posterior_coo2 = sp.random(m, n, density=0.08, format='coo', dtype=float)
-    noise_offsets = dict(zip(np.random.randint(low=0, high=(m - 1), size=10),
-                             np.random.randint(low=1, high=5, size=10)))
+    if blank_noise_offsets:
+        noise_offsets = {}
+    else:
+        noise_offsets = dict(zip(np.random.randint(low=0, high=(m - 1), size=10),
+                                 np.random.randint(low=1, high=5, size=10)))
     kwargs = {'a': 'b', 'c': 1}
     kwargs2 = {'a': 'method', 'c': 1}
 
@@ -417,7 +421,7 @@ def test_save_and_load(tmpdir_factory):
             assert sparse_matrix_equal(val1, val2), err_msg
         elif type(val1) == np.ndarray:
             np.testing.assert_equal(val1, val2)
-        elif (type(val1) == dict) and (type(list(val1.values())[0]) == np.ndarray):
+        elif (type(val1) == dict) and (val1 != {}) and (type(list(val1.values())[0]) == np.ndarray):
             for k in val1.keys():
                 np.testing.assert_equal(val1[k], val2[k])
         else:

--- a/wdl/cellbender_remove_background.wdl
+++ b/wdl/cellbender_remove_background.wdl
@@ -186,7 +186,7 @@ task run_cellbender_remove_background_gpu {
         nvidiaDriverVersion: "${nvidia_driver_version}"
         preemptible: hardware_preemptible_tries
         checkpointFile: "ckpt.tar.gz"
-        maxRetries: 0
+        maxRetries: 1  # in case of a PAPI error code 2 failure to install GPU drivers
     }
     meta {
         author: "Stephen Fleming"


### PR DESCRIPTION
Changes:
- save and load posterior as an h5 file rather than a numpy NPZ
    - I had thought NPZ would just be easier, but it has caused a lot of headaches: it is super slow, and it causes a massive memory spike during save, which can overflow memory
- address some bugs in `estimation.py`
- potential improvement to `chunked_iterator()` in `estimation.py` that helps to make sure we do not waste time getting small / empty chunks from the iterator

Closes #207 , #205 

Potentially touches on #206 , but have not evaluated thoroughly