### PR TITLE
Bug fix for WDL using MTX input

### DIFF
--- a/wdl/cellbender_remove_background.wdl
+++ b/wdl/cellbender_remove_background.wdl
@@ -124,8 +124,15 @@ task run_cellbender_remove_background_gpu {
             [ -f $dir/$name ] || mv ~{genes_file} $dir/$name
         fi
 
+        # use the directory as the input in the case of an MTX file
+        if [[ "~{input_file_unfiltered}" == *.mtx ]]; then
+            input=$(dirname ~{input_file_unfiltered})
+        else
+            input=~{input_file_unfiltered}
+        fi
+
         cellbender remove-background \
-            --input "~{input_file_unfiltered}" \
+            --input $input \
             --output "~{sample_name}_out.h5" \
             --cuda \
             ~{"--checkpoint " + checkpoint_file} \

--- a/wdl/cellbender_remove_background.wdl
+++ b/wdl/cellbender_remove_background.wdl
@@ -125,7 +125,7 @@ task run_cellbender_remove_background_gpu {
         fi
 
         # use the directory as the input in the case of an MTX file
-        if [[ "~{input_file_unfiltered}" == *.mtx ]]; then
+        if [[ "~{input_file_unfiltered}" == *.mtx* ]]; then
             input=$(dirname ~{input_file_unfiltered})
         else
             input=~{input_file_unfiltered}


### PR DESCRIPTION
Closes #245 

Instead of using `input_file_unfiltered` as the cellbender `--input` argument directly, it checks whether it is an MTX file. The `--input` remains `input_file_unfiltered` unless the input is an MTX file, in which case it becomes the directory name `$(dirname ~{input_file_unfiltered})`.

This obeys cellbender's current expectation that an MTX format input is to be specified by passing a directory as `--input`.