### PR TITLE
os.replace() instead of os.rename() to save checkpoint

### DIFF
--- a/cellbender/remove_background/checkpoint.py
+++ b/cellbender/remove_background/checkpoint.py
@@ -297,7 +297,7 @@ def make_tarball(files: List[str], tarball_name: str) -> bool:
         for file in files:
             # without arcname, unpacking results in unpredictable file locations!
             tar.add(file, arcname=os.path.basename(file))
-    os.rename(tarball_name + '.tmp', tarball_name)
+    os.replace(tarball_name + '.tmp', tarball_name)
     return True
 
 


### PR DESCRIPTION
Closes #250

I did not realize this, but `os.rename()` will error in Windows if the destination file already exists.

`os.replace()` is the correct replacement.

Notes:
This is intended to be an atomic operation to move the temporary checkpoint file to its final location. We need the final checkpoint file to be complete at all times -- otherwise, another process trying to access the checkpoint file (like Cromwell copying for instance) could encounter a half-written checkpoint file, and we would set up a race condition.