### PR TITLE
os.replace() instead of os.rename() to save checkpoint

### DIFF
--- a/cellbender/remove_background/checkpoint.py
+++ b/cellbender/remove_background/checkpoint.py
@@ -297,7 +297,7 @@ def make_tarball(files: List[str], tarball_name: str) -> bool:
         for file in files:
             # without arcname, unpacking results in unpredictable file locations!
             tar.add(file, arcname=os.path.basename(file))
-    os.rename(tarball_name + '.tmp', tarball_name)
+    os.replace(tarball_name + '.tmp', tarball_name)
     return True
 
 


### PR DESCRIPTION
Fixes Windows bug #250

Merging it into `sf_posterior_int_overflow` because I added a Windows github action test there, and the test fails without this fix.