### PR TITLE
Memory-efficient posterior generation

### DIFF
--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -535,7 +535,8 @@ class Posterior:
             m_i = self.index_converter.get_m_indices(cell_inds=bcs_i, gene_inds=genes_i)
 
             nonzero_noise_offset_dict.update(
-                dict(zip(m_i[nonzero_offset_inds], nonzero_noise_count_offsets))
+                dict(zip(m_i[nonzero_offset_inds.detach().cpu()].tolist(),
+                         nonzero_noise_count_offsets.detach().cpu().tolist()))
             )
             c_offset.append(noise_count_offset_NG[bcs_i_chunk, genes_i_analyzed].detach().cpu())
 

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -528,31 +528,8 @@ class Posterior:
             log_probs.append(log_prob_i.detach().cpu())
             c_offset.append(noise_count_offset_NG[bcs_i_chunk, genes_i_analyzed].detach().cpu())
 
-            # try:
-            #     bcs.extend(bcs_i.tolist())
-            #     genes.extend(genes_i.tolist())
-            #     c.extend(c_i.tolist())
-            #     log_probs.extend(log_prob_i.tolist())
-            #     c_offset.extend(noise_count_offset_NG[bcs_i_chunk, genes_i_analyzed]
-            #                     .detach().cpu().numpy())
-            # except TypeError as e:
-            #     # edge case of a single value
-            #     bcs.append(bcs_i)
-            #     genes.append(genes_i)
-            #     c.append(c_i)
-            #     log_probs.append(log_prob_i)
-            #     c_offset.append(noise_count_offset_NG[bcs_i_chunk, genes_i_analyzed]
-            #                     .detach().cpu().numpy())
-
             # Increment barcode index counter.
             ind += data.shape[0]  # Same as data_loader.batch_size
-
-        # # Convert the lists to numpy arrays.
-        # log_probs = np.array(log_probs, dtype=float)
-        # c = np.array(c, dtype=np.uint32)
-        # barcodes = np.array(bcs, dtype=np.uint64)  # uint32 is too small!
-        # genes = np.array(genes, dtype=np.uint64)  # use same as above for IndexConverter
-        # noise_count_offsets = np.array(c_offset, dtype=np.uint32)
 
         # Concatenate lists.
         log_probs = torch.cat(log_probs)

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -513,17 +513,17 @@ class Posterior:
             genes_i = analyzed_gene_inds[genes_i_analyzed.cpu()]
 
             # Barcode index in the dataloader.
-            bcs_i = bcs_i_chunk + ind
+            bcs_i = (bcs_i_chunk + ind).cpu()
 
             # Obtain the real barcode index since we only use cells.
             bcs_i = dataloader_index_to_analyzed_bc_index[bcs_i]
 
             # Translate chunk barcode inds to overall inds.
-            bcs_i = barcode_inds[bcs_i.cpu()]
+            bcs_i = barcode_inds[bcs_i]
 
             # Add sparse matrix values to lists.
-            bcs.append(bcs_i.detach().cpu())
-            genes.append(genes_i.detach().cpu())
+            bcs.append(bcs_i.detach())
+            genes.append(genes_i.detach())
             c.append(c_i.detach().cpu())
             log_probs.append(log_prob_i.detach().cpu())
             c_offset.append(noise_count_offset_NG[bcs_i_chunk, genes_i_analyzed].detach().cpu())

--- a/cellbender/remove_background/sparse_utils.py
+++ b/cellbender/remove_background/sparse_utils.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple, Iterable
 @torch.no_grad()
 def dense_to_sparse_op_torch(t: torch.Tensor,
                              tensor_for_nonzeros: Optional[torch.Tensor] = None) \
-        -> Tuple[np.ndarray, ...]:
+        -> Tuple[torch.Tensor, ...]:
     """Converts dense matrix to sparse COO format tuple of numpy arrays (*indices, data)
 
     Args:
@@ -28,9 +28,9 @@ def dense_to_sparse_op_torch(t: torch.Tensor,
         tensor_for_nonzeros = t
 
     nonzero_inds_tuple = torch.nonzero(tensor_for_nonzeros, as_tuple=True)
-    nonzero_values = t[nonzero_inds_tuple].flatten()
+    nonzero_values = t[nonzero_inds_tuple].flatten().clone()
 
-    return tuple([ten.cpu().numpy() for ten in (nonzero_inds_tuple + (nonzero_values,))])
+    return nonzero_inds_tuple + (nonzero_values,)
 
 
 def log_prob_sparse_to_dense(coo: sp.coo_matrix) -> np.ndarray:

--- a/cellbender/remove_background/tests/test_dataprep.py
+++ b/cellbender/remove_background/tests/test_dataprep.py
@@ -75,9 +75,9 @@ def test_dataloader_sorting(simulated_dataset, cuda):
             bcs_i = loader.unsort_inds(bcs_i)
 
             # Add sparse matrix values to lists.
-            barcodes.append(bcs_i)
-            genes.append(genes_i)
-            counts.append(counts_i)
+            barcodes.append(bcs_i.detach().cpu())
+            genes.append(genes_i.detach().cpu())
+            counts.append(counts_i.detach().cpu())
 
             # Increment barcode index counter.
             ind += data.shape[0]  # Same as data_loader.batch_size

--- a/cellbender/remove_background/tests/test_sparse_utils.py
+++ b/cellbender/remove_background/tests/test_sparse_utils.py
@@ -76,9 +76,9 @@ def test_dense_to_sparse_op_torch(simulated_dataset, cuda):
         bcs_i = data_loader.unsort_inds(bcs_i)
 
         # Add sparse matrix values to lists.
-        barcodes.append(bcs_i)
-        genes.append(genes_i)
-        counts.append(counts_i)
+        barcodes.append(bcs_i.detach().cpu())
+        genes.append(genes_i.detach().cpu())
+        counts.append(counts_i.detach().cpu())
 
         # Increment barcode index counter.
         ind += data.shape[0]  # Same as data_loader.batch_size


### PR DESCRIPTION
It has become apparent that something during the posterior generation process in v0.3.0 is gobbling up way too much memory, more than previous versions.  See #251 #248 

Conceptually, in v2:
- for each minibatch
    - compute the posterior
    - estimating the noise counts
    - keep only the noise counts

Conceptually, in v3:
- for each minibatch
    - compute the posterior
    - keep a sparse representation in memory
- save the full sparse posterior as an h5 file
- use an "estimator" applied to the full sparse posterior

This refactor allows us to do a whole lot more.  But it also involves computing and saving the full posterior, which was not attempted in v2.  While it is perfectly doable (these posterior h5 files are usually less than 2GB), it seems it needed to be done a bit more carefully.

I think the extension of python lists left around objects in memory (by creating references to them) that I did not intend.

Adopting another strategy: keep a python list of (sparsified info as) torch tensors.  Append tensors to the lists each minibatch.  Concatenate them once and for all at the end.  All these tensors are cloned from the originals, detached, and kept in cpu memory.

Closes #248 
Closes #251 