### PR TITLE
Update cli.py to add newer Cell Ranger feature types

### DIFF
--- a/cellbender/remove_background/cli.py
+++ b/cellbender/remove_background/cli.py
@@ -117,14 +117,22 @@ class CLI(AbstractCLI):
         args.fpr = fpr_list_correct_dtypes
 
         # Ensure that "exclude_features" specifies allowed features.
-        # As of CellRanger 6.0, the possible features are:
+        # As of CellRanger 7.2, the possible features are:
         #     Gene Expression
         #     Antibody Capture
         #     CRISPR Guide Capture
         #     Custom
         #     Peaks
+        #     Multiplexing Capture
+        #     VDJ
+        #     VDJ-T
+        #     VDJ-T-GD
+        #     VDJ-B
+        #     Antigen Capture
         allowed_features = ['Gene Expression', 'Antibody Capture',
-                            'CRISPR Guide Capture', 'Custom', 'Peaks']
+                            'CRISPR Guide Capture', 'Custom', 'Peaks',
+                            'Multiplexing Capture', 'VDJ', 'VDJ-T',
+                            'VDJ-T-GD', 'VDJ-B', 'Antigen Capture']
         for feature in args.exclude_features:
             if feature not in allowed_features:
                 sys.stdout.write(f"Specified '{feature}' using --exclude-feature-types, "


### PR DESCRIPTION
Closes #340 

In Cell Ranger 7+, there is a longer list of [feature types](https://www.10xgenomics.com/support/software/cell-ranger/7.2/advanced/cr-multi-config-csv-opts#feature-types) one can specify in `cellranger multi`. These should be added to the list of allowed feature types in CellBender so they won't be rejected by `--exclude-feature-types` (the Multiplexing Capture feature is of particular note here).