### PR TITLE
Changed np.int to np.int64 as the use of np.int is now deprecated

### DIFF
--- a/cellbender/remove_background/data/io.py
+++ b/cellbender/remove_background/data/io.py
@@ -950,7 +950,7 @@ def get_matrix_from_bd_rhapsody(filename: str) \
             # Parse row into gene name and count data
             parsed_line = line.split('\n')[0].split(',')
             barcodes.append(parsed_line[0])
-            counts = np.array(parsed_line[1:], dtype=np.int)
+            counts = np.array(parsed_line[1:], dtype=np.int64)
 
             # Create sparse version of data and add to arrays
             nonzero_col_inds = np.nonzero(counts)[0]

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -218,7 +218,7 @@ def _estimation_array_to_csr(index_converter,
                              data: np.ndarray,
                              m: np.ndarray,
                              noise_offsets: Optional[Dict[int, int]],
-                             dtype=np.int) -> sp.csr_matrix:
+                             dtype=np.int64) -> sp.csr_matrix:
     """Say you have point estimates for each count matrix element (data) and
     you have the 'm'-indices for each value (m). This returns a CSR matrix
     that has the shape of the count matrix, where duplicate entries have


### PR DESCRIPTION
After following installation instructions and running CellBender over my data I received the following error:

>AttributeError: module 'numpy' has no attribute 'int'.
>np.int was a deprecated alias for the builtin int. To avoid this error in existing code, use int by itself.

To fix the problem I've changed `np.int` to `np.int64` in two places. After doing so and installing the package from this source the error did not happen anymore.