### PR TITLE
fixed tarball wrong save name 

### DIFF
--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -111,7 +111,7 @@ def run_remove_background(args: argparse.Namespace) -> Posterior:
     if args.model == 'naive':
         inferred_model = None
     else:
-        inferred_model, _, _, _ = run_inference(dataset_obj=dataset_obj, args=args)
+        inferred_model, _, _, _ = run_inference(dataset_obj=dataset_obj, args=args, output_checkpoint_tarball=args.input_checkpoint_tarball)
         inferred_model.eval()
 
     try:


### PR DESCRIPTION
When specifying another name than the default using the --checkoint flag the file still got saved to the default, effectively not allowing any cellbender instances to run concurrently. This fixes the issue. 