### PR TITLE
Allow custom checkpoint location

### DIFF
--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -634,11 +634,6 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
                                    force_use_checkpoint=args.force_use_checkpoint)
     ckpt_loaded = ckpt['loaded']  # True if a checkpoint was loaded successfully
 
-    # If checkpoint is not loaded set output_checkpoint_tarball to checkpoint_filename
-    # In this way the user can use checkpoint option to set a custom locatio for checkpoint file
-    if not ckpt_loaded:
-        output_checkpoint_tarball = checkpoint_filename
-
     if ckpt_loaded:
 
         model = ckpt['model']
@@ -657,6 +652,11 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
     else:
 
         logger.info('No checkpoint loaded.')
+
+        # If checkpoint is not loaded set output_checkpoint_tarball to checkpoint_filename
+        # In this way the user can use checkpoint option to set a custom locatio for checkpoint file
+        output_checkpoint_tarball = args.input_checkpoint_tarball
+        logger.info(f'New checkpoint file will be saved as {output_checkpoint_tarball}')
 
         # Get the trimmed count matrix (transformed if called for).
         count_matrix = dataset_obj.get_count_matrix()

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -634,6 +634,11 @@ def run_inference(dataset_obj: SingleCellRNACountsDataset,
                                    force_use_checkpoint=args.force_use_checkpoint)
     ckpt_loaded = ckpt['loaded']  # True if a checkpoint was loaded successfully
 
+    # If checkpoint is not loaded set output_checkpoint_tarball to checkpoint_filename
+    # In this way the user can use checkpoint option to set a custom locatio for checkpoint file
+    if not ckpt_loaded:
+        output_checkpoint_tarball = checkpoint_filename
+
     if ckpt_loaded:
 
         model = ckpt['model']


### PR DESCRIPTION
Hi.

This pull request introduces a small change to run.py that solves #405 and similar issues.

When the user defines a custom checkpoint location using `--checkpoint`, if the defined file does not exist, a new checkpoint tarball file is created using the path defined by this option.

In this way, the user can now control the exact location of the checkpoint file when needed instead of the current behavior, where the checkpoint file is always saved to the current working directory.

I've tested this update against the standard 0.3.2 version, and they produced identical results.