### PR TITLE
Update to Python 3.9 and PyTorch 2

### DIFF
--- a/.github/workflows/miniwdl_check.yml
+++ b/.github/workflows/miniwdl_check.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: 'Install miniwdl and Run Validation Test'
         run: |
           pip install miniwdl==$MINIWDL_VERSION;

--- a/.github/workflows/run_packaging_check.yml
+++ b/.github/workflows/run_packaging_check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.9']
 
     steps:
     - name: 'Checkout repo'

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        python-version: ['3.7']
+        python-version: ['3.9']
 
     runs-on: ${{ matrix.os }}
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.9"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ Create a conda environment and activate it:
 
 .. code-block:: console
 
-  $ conda create -n cellbender python=3.7
+  $ conda create -n cellbender python=3.9
   $ conda activate cellbender
 
 Install the `pytables <https://www.pytables.org>`_ module:

--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -134,8 +134,8 @@ def generate_summary_plots(input_file: str,
     adata.var['n_removed'] = adata.var[f'n_{input_layer_key}'] - adata.var[f'n_{out_key}']
     adata.var['fraction_removed'] = adata.var['n_removed'] / (adata.var[f'n_{input_layer_key}'] + 1e-5)
     adata.var['fraction_remaining'] = adata.var[f'n_{out_key}'] / (adata.var[f'n_{input_layer_key}'] + 1e-5)
-    adata.var[f'n_{input_layer_key}_cells'] = np.array(adata.layers[input_layer_key][cells].sum(axis=0)).squeeze()
-    adata.var[f'n_{out_key}_cells'] = np.array(adata.layers[out_key][cells].sum(axis=0)).squeeze()
+    adata.var[f'n_{input_layer_key}_cells'] = np.array(adata.layers[input_layer_key][cells.values].sum(axis=0)).squeeze()
+    adata.var[f'n_{out_key}_cells'] = np.array(adata.layers[out_key][cells.values].sum(axis=0)).squeeze()
     adata.var['n_removed_cells'] = (adata.var[f'n_{input_layer_key}_cells']
                                     - adata.var[f'n_{out_key}_cells'])
     adata.var['fraction_removed_cells'] = (adata.var['n_removed_cells']
@@ -369,8 +369,8 @@ def plot_input_umi_curve(inputfile):
 def assess_overall_count_removal(adata, raw_full_adata, input_layer_key='raw', out_key='cellbender'):
     global warnings
     cells = (adata.obs['cell_probability'] > 0.5)
-    initial_counts = adata.layers[input_layer_key][cells].sum()
-    removed_counts = initial_counts - adata.layers[out_key][cells].sum()
+    initial_counts = adata.layers[input_layer_key][cells.values].sum()
+    removed_counts = initial_counts - adata.layers[out_key][cells.values].sum()
     removed_percentage = removed_counts / initial_counts * 100
     print(f'removed {removed_counts:.0f} counts from non-empty droplets')
     print(f'removed {removed_percentage:.2f}% of the counts in non-empty droplets')
@@ -775,7 +775,7 @@ def plot_counts_and_probs_per_cell(adata, input_layer_key='raw'):
     limit_to_features_analyzed = True
 
     if limit_to_features_analyzed:
-        var_logic = adata.var['cellbender_analyzed']
+        var_logic = adata.var['cellbender_analyzed'].values
     else:
         var_logic = ...
 

--- a/cellbender/remove_background/tests/test_checkpoint.py
+++ b/cellbender/remove_background/tests/test_checkpoint.py
@@ -7,11 +7,12 @@ import torch
 from torch.distributions import constraints
 import pyro
 import pyro.optim as optim
+import dill
 
 import cellbender
 from cellbender.remove_background.checkpoint import make_tarball, unpack_tarball, \
     create_workflow_hashcode, save_checkpoint, load_checkpoint, \
-    save_random_state, load_random_state
+    save_random_state, load_random_state, load_param_store
 from cellbender.remove_background.vae.encoder import EncodeZ, EncodeNonZLatents, \
     CompositeEncoder
 from cellbender.remove_background.vae.decoder import Decoder
@@ -600,7 +601,7 @@ def test_optimizer_checkpoint_restart(Optim, config, tmpdir_factory):
     store.clear()
 
     # load from checkpoint
-    store.load(param_filename)
+    load_param_store(param_filename)
     optimizer = Optim(config.copy())
     optimizer.load(optim_filename)
     svi = pyro.infer.SVI(model, guide, optimizer, pyro.infer.Trace_ELBO())

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -26,7 +26,7 @@ packages you may have installed.
 
 .. code-block:: console
 
-  $ conda create -n cellbender python=3.7
+  $ conda create -n cellbender python=3.9
   $ conda activate cellbender
   (cellbender) $ pip install cellbender
 
@@ -38,7 +38,7 @@ Create a conda environment and activate it:
 
 .. code-block:: console
 
-  $ conda create -n cellbender python=3.7
+  $ conda create -n cellbender python=3.9
   $ conda activate cellbender
 
 Install the `pytables <https://www.pytables.org>`_ module:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dynamic = ["version", "dependencies", "optional-dependencies"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ notebook<7.0.0
 nbconvert<7.0.0
 lxml_html_clean
 psutil
+dill>0.3.1


### PR DESCRIPTION
Inspired by #203 , I wanted to modernize CellRanger a bit, but with Python 3.9 since it is now the minimum version supported by PyTorch.

The issues with Pyro mentioned in #203 have already been fixed, so the (hopefully) only remaining hurdle is #212. A workaround for the weakref issue was mentioned in #386, but this breaks deserialization. I though I was going to have to extensively refactor the model, but it turns out that this can be fixed by simply using dill instead of pickle. Additionally, some changes to report.py were needed, I think because of changes with pandas and/or numpy.

I increased the version numbers as in #203, but there were several other changes that I was not sure about that I did not include here.

Making these changes, I have all tests passing with Python 3.9 and 3.12 using PyTorch 2.7.1 on an RTX 5060 Ti. It will presumably work on other PyTorch versions >= 2 , but I don't think I can test them with my hardware.