### PR TITLE
Revert "Fix OSEerror: Invalid cross-device link by replacing os.replace with shutil.move in report.py"

### DIFF
--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -51,7 +51,7 @@ def _run_notebook(file):
 
 def _to_html(file, output) -> str:
     subprocess.run(to_html_str(file=file, output=output), shell=True)
-    shutil.move(file.replace(".ipynb", ".html"), output)
+    os.replace(file.replace(".ipynb", ".html"), output)
     os.remove(file)
     return output
 


### PR DESCRIPTION
Reverts broadinstitute/CellBender#399