### PR TITLE
Fix OSEerror: Invalid cross-device link by replacing os.replace with shutil.move

### DIFF
--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -51,7 +51,7 @@ def _run_notebook(file):
 
 def _to_html(file, output) -> str:
     subprocess.run(to_html_str(file=file, output=output), shell=True)
-    os.replace(file.replace(".ipynb", ".html"), output)
+    shutil.move(file.replace(".ipynb", ".html"), output)
     os.remove(file)
     return output
 


### PR DESCRIPTION
Targeting the dev branch as requested by @sjfleming on #399  

Replaced os.replace with shutil.move to prevent OSEerror: Invalid cross-device link: 'tmp.report.nbconvert.html' -> ,<YOUR_CLUSTER_DIRECTORY>

This allows the html report to be generated and saved across file systems. Useful when working on a high performance distributed computing system.

