### PR TITLE
Docker build/push github action fix for manual trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ steps.version.outputs.value }}
           fetch-depth: 0  # required for setuptools-git-versioning to read tags
 
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
Manual trigger of the docker github action checks out intended `version` branch or tag.  Previously it was just using the branch the action was triggered from