### PR TITLE
suppress pandas warnings

### DIFF
--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -374,7 +374,7 @@ def _mckp_chunk_estimate_noise(
     df_out = (
         df[["m", "g", "delta", "topk"]]
         .groupby("g", group_keys=False)
-        .apply(lambda x: x.nsmallest(x["topk"].iat[0], columns="delta"))
+        .apply(lambda x: x.nsmallest(x["topk"].iat[0], columns="delta"), include_groups=False)
     )
     logger.debug(f"{timestamp()} Computing nsmallest done")
 
@@ -670,7 +670,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
         df_out = (
             df[["m", "g", "delta", "topk"]]
             .groupby("g", group_keys=False)
-            .apply(lambda x: x.nsmallest(x["topk"].iat[0], columns="delta"))
+            .apply(lambda x: x.nsmallest(x["topk"].iat[0], columns="delta"), include_groups=False)
         )
         logger.debug(f"{timestamp()} Computing nsmallest done")
 


### PR DESCRIPTION
New pandas version led to a ton of warnings during final noise count estimation.

Fix the problem by updating pandas syntax, thereby removing the warnings.