### PR TITLE
add faster implementations of Mean and MCKP estimators

### DIFF
--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -336,7 +336,7 @@ def add_subparser_args(subparsers: argparse._SubParsersAction) -> argparse._SubP
         "--estimator",
         type=str,
         default="mckp",
-        choices=["map", "mean", "cdf", "sample", "mckp"],
+        choices=["map", "mean", "cdf", "sample", "mckp", "fast-mckp"],
         dest="estimator",
         help="Output denoised count estimation method. (For "
         "experts: not required for normal usage, see "

--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -336,7 +336,7 @@ def add_subparser_args(subparsers: argparse._SubParsersAction) -> argparse._SubP
         "--estimator",
         type=str,
         default="mckp",
-        choices=["map", "mean", "cdf", "sample", "mckp", "fast-mckp"],
+        choices=["map", "mean", "cdf", "sample", "mckp", "fast-mckp", "fast-mckp2"],
         dest="estimator",
         help="Output denoised count estimation method. (For "
         "experts: not required for normal usage, see "

--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -336,7 +336,7 @@ def add_subparser_args(subparsers: argparse._SubParsersAction) -> argparse._SubP
         "--estimator",
         type=str,
         default="mckp",
-        choices=["map", "mean", "cdf", "sample", "mckp", "fast-mckp", "fast-mckp2"],
+        choices=["map", "mean", "cdf", "sample", "mckp", "fast-mckp"],
         dest="estimator",
         help="Output denoised count estimation method. (For "
         "experts: not required for normal usage, see "

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -177,17 +177,59 @@ class Mean(EstimationMethod):
         Returns:
             noise_count_csr: Estimated noise count matrix.
         """
-        # c = torch.arange(noise_log_prob_coo.shape[1], dtype=float).to(device).t()
 
-        def _torch_mean(x):
-            c = torch.arange(x.shape[1], dtype=float).to(x.device)
-            return torch.matmul(x.exp(), c.t())
+        # TODO: I don't think xp.asnumpy will work if CuPy is not installed
 
-        result = apply_function_dense_chunks(noise_log_prob_coo=noise_log_prob_coo, fun=_torch_mean, device=device)
-        return self._estimation_array_to_csr(
-            data=result["result"], m=result["m"], noise_offsets=noise_offsets, dtype=np.float32
+        # TODO: noise_log_prob_coo.has_canonical_form is false to begin with, which freaks me out.
+        #       noise_log_prob_coo.sum_duplicates() fixes it, but takes a few seconds.
+        #       This should probably be called before saving the posterior, but why are there duplicates to begin with?
+
+        t0 = time.time()
+
+        xp = cp if device == "cuda" else np
+
+        c = xp.asarray(noise_log_prob_coo.col)
+
+        data = xp.asarray(noise_log_prob_coo.data, copy=True)
+        xp.exp(data, out = data)
+
+        # Indices are grouped by m.
+        # group_indices is an array of length m that indexes into _ = xp.unique(m) such that _[group_indices] == m.
+        _, group_indices, group_sizes = xp.unique(xp.asarray(noise_log_prob_coo.row),
+                                                  return_inverse=True,
+                                                  return_counts=True)
+
+        # Gets the mean for each group.
+        # len(group_means) == group_indices.max() + 1 == len(xp.unique(m))
+        # Divides by group_sizes since the csr constructor sums data with duplicate coords.
+        group_means = xp.bincount(group_indices, weights=data * c) / group_sizes
+
+        # Since group_means is ordered the same as xp.unique(m), we can invert it.
+        data_out = group_means[group_indices]
+
+        if noise_offsets is not None and len(noise_offsets.keys()) != 0:
+            noise_offsets_n, noise_offsets_g = (
+                self.index_converter.get_ng_indices(m_inds=np.fromiter(noise_offsets.keys(), dtype=np.int64))
+            )
+        else:
+            noise_offsets_n, noise_offsets_g = None, None
+
+        new_return = sp.csr_matrix(
+            (xp.asnumpy(data_out) if device == "cuda" else data_out,
+             self.index_converter.get_ng_indices(noise_log_prob_coo.row)),
+            shape=self.index_converter.matrix_shape,
+            dtype=np.float32,
         )
 
+        if noise_offsets is not None and len(noise_offsets.keys()) != 0:
+            new_return[noise_offsets_n, noise_offsets_g] += np.fromiter(noise_offsets.values(), dtype=np.int64)
+
+        new_return.eliminate_zeros()
+        new_return.sum_duplicates()
+
+        logger.info(f"Mean.estimate_noise(): time = {(time.time() - t0):.2f} sec")
+
+        return new_return
 
 class MAP(EstimationMethod):
     """The canonical maximum a posteriori"""

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -986,6 +986,9 @@ def _estimate_fast_mckp2(
 
     print(f"{timestamp()} fast-mckp2 process {process_index} time = {(time.time() - t0):.2f} sec")
 
+    if use_multiple_processes:
+        out_stack_queue.join()
+
     return out_csr
 
 class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
@@ -1130,7 +1133,7 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
         if use_multiple_processes:
             gene_chunks = torch.arange(unique_genes.shape[0], device=device).tensor_split(n_processes)
 
-            out_stack_queue = torchmp.Queue()
+            out_stack_queue = torchmp.JoinableQueue()
 
             # Sharing CUDA tensors requires spawn or forkserver.
             # Only spawn works on Windows and Mac, but is slow.
@@ -1183,6 +1186,9 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
                 )
 
                 del out_stack
+
+            for i in range(n_processes):
+                out_stack_queue.task_done()
 
             process_context.join()
 

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -177,17 +177,59 @@ class Mean(EstimationMethod):
         Returns:
             noise_count_csr: Estimated noise count matrix.
         """
-        # c = torch.arange(noise_log_prob_coo.shape[1], dtype=float).to(device).t()
 
-        def _torch_mean(x):
-            c = torch.arange(x.shape[1], dtype=float).to(x.device)
-            return torch.matmul(x.exp(), c.t())
+        # TODO: I don't think xp.asnumpy will work if CuPy is not installed
 
-        result = apply_function_dense_chunks(noise_log_prob_coo=noise_log_prob_coo, fun=_torch_mean, device=device)
-        return self._estimation_array_to_csr(
-            data=result["result"], m=result["m"], noise_offsets=noise_offsets, dtype=np.float32
+        # TODO: noise_log_prob_coo.has_canonical_form is false to begin with, which freaks me out.
+        #       noise_log_prob_coo.sum_duplicates() fixes it, but takes a few seconds.
+        #       This should probably be called before saving the posterior, but why are there duplicates to begin with?
+
+        t0 = time.time()
+
+        xp = cp if device == "cuda" else np
+
+        c = xp.asarray(noise_log_prob_coo.col)
+
+        data = xp.asarray(noise_log_prob_coo.data, copy=True)
+        xp.exp(data, out = data)
+
+        # Indices are grouped by m.
+        # group_indices is an array of length m that indexes into _ = xp.unique(m) such that _[group_indices] == m.
+        _, group_indices, group_sizes = xp.unique(xp.asarray(noise_log_prob_coo.row),
+                                                  return_inverse=True,
+                                                  return_counts=True)
+
+        # Gets the mean for each group.
+        # len(group_means) == group_indices.max() + 1 == len(xp.unique(m))
+        # Divides by group_sizes since the csr constructor sums data with duplicate coords.
+        group_means = xp.bincount(group_indices, weights=data * c) / group_sizes
+
+        # Since group_means is ordered the same as xp.unique(m), we can invert it.
+        data_out = group_means[group_indices]
+
+        if noise_offsets is not None:
+            noise_offsets_n, noise_offsets_g = (
+                self.index_converter.get_ng_indices(m_inds=np.fromiter(noise_offsets.keys(), dtype=np.int64))
+            )
+        else:
+            noise_offsets_n, noise_offsets_g = None, None
+
+        new_return = sp.csr_matrix(
+            (xp.asnumpy(data_out) if device == "cuda" else data_out,
+             self.index_converter.get_ng_indices(noise_log_prob_coo.row)),
+            shape=self.index_converter.matrix_shape,
+            dtype=np.float32,
         )
 
+        if noise_offsets is not None:
+            new_return[noise_offsets_n, noise_offsets_g] += np.fromiter(noise_offsets.values(), dtype=np.int64)
+
+        new_return.eliminate_zeros()
+        new_return.sum_duplicates()
+
+        logger.info(f"Mean.estimate_noise(): time = {(time.time() - t0):.2f} sec")
+
+        return new_return
 
 class MAP(EstimationMethod):
     """The canonical maximum a posteriori"""

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -163,6 +163,7 @@ class SingleSample(EstimationMethod):
 class Mean(EstimationMethod):
     """Posterior mean"""
 
+    @torch.no_grad()
     def estimate_noise(
         self, noise_log_prob_coo: sp.coo_matrix, noise_offsets: Optional[Dict[int, int]], device: str = "cpu", **kwargs
     ) -> sp.csr_matrix:
@@ -178,33 +179,29 @@ class Mean(EstimationMethod):
             noise_count_csr: Estimated noise count matrix.
         """
 
-        # TODO: I don't think xp.asnumpy will work if CuPy is not installed
-
         # TODO: noise_log_prob_coo.has_canonical_form is false to begin with, which freaks me out.
         #       noise_log_prob_coo.sum_duplicates() fixes it, but takes a few seconds.
         #       This should probably be called before saving the posterior, but why are there duplicates to begin with?
 
         t0 = time.time()
 
-        xp = cp if device == "cuda" else np
+        c = torch.from_numpy(noise_log_prob_coo.col).to(device=device)
 
-        c = xp.asarray(noise_log_prob_coo.col)
-
-        data = xp.asarray(noise_log_prob_coo.data, copy=True)
-        xp.exp(data, out = data)
+        data = torch.from_numpy(noise_log_prob_coo.data).to(device=device, copy=True)
+        torch.exp(data, out=data)
 
         # Indices are grouped by m.
-        # group_indices is an array of length m that indexes into _ = xp.unique(m) such that _[group_indices] == m.
-        _, group_indices, group_sizes = xp.unique(xp.asarray(noise_log_prob_coo.row),
-                                                  return_inverse=True,
-                                                  return_counts=True)
+        # group_indices is an array of length m that indexes into _ = torch.unique(m) such that _[group_indices] == m.
+        _, group_indices, group_sizes = torch.unique(
+            torch.from_numpy(noise_log_prob_coo.row).to(device=device), return_inverse=True, return_counts=True
+        )
 
         # Gets the mean for each group.
-        # len(group_means) == group_indices.max() + 1 == len(xp.unique(m))
+        # len(group_means) == group_indices.max() + 1 == len(torch.unique(m))
         # Divides by group_sizes since the csr constructor sums data with duplicate coords.
-        group_means = xp.bincount(group_indices, weights=data * c) / group_sizes
+        group_means = torch.bincount(group_indices, weights=data * c) / group_sizes
 
-        # Since group_means is ordered the same as xp.unique(m), we can invert it.
+        # Since group_means is ordered the same as torch.unique(m), we can invert it.
         data_out = group_means[group_indices]
 
         if noise_offsets is not None:
@@ -215,7 +212,7 @@ class Mean(EstimationMethod):
             noise_offsets_n, noise_offsets_g = None, None
 
         new_return = sp.csr_matrix(
-            (xp.asnumpy(data_out) if device == "cuda" else data_out,
+            (data_out.numpy(force=True) if device == "cuda" else data_out,
              self.index_converter.get_ng_indices(noise_log_prob_coo.row)),
             shape=self.index_converter.matrix_shape,
             dtype=np.float32,

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -1064,6 +1064,9 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
         if not use_multiple_processes:
             torch.set_num_threads(n_threads_per_process_single)
 
+        # Release unused memory so the usage reported by nvidia-smi doesn't appear to be higher than it actually is.
+        torch.cuda.empty_cache()
+
         # TODO: test RAM and VRAM usage
 
         # p-core/e-core counts are hard to get programmatically without obscure hacks.
@@ -1127,6 +1130,8 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
         noise_targets_per_gene = noise_targets_per_gene.to(device)
 
         t_setup = time.time()
+
+        torch.cuda.empty_cache()
 
         logger.info(f"{timestamp()} fast-mckp2 setup time = {(t_setup - t0):.2f} sec")
 
@@ -1222,6 +1227,8 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
             )
 
         torch.set_num_threads(original_torch_num_thread)
+
+        torch.cuda.empty_cache()
 
         logger.info(f"{timestamp()} fast-mckp2 estimation time after prep = {(time.time() - t_setup):.2f} sec")
         logger.info(f"{timestamp()} Total fast-mckp2 estimation time = {(time.time() - t0):.2f} sec")

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -3,6 +3,8 @@
 import concurrent.futures
 import logging
 import multiprocessing as mp
+from multiprocessing import shared_memory
+from multiprocessing.managers import SharedMemoryManager
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -85,6 +87,48 @@ class EstimationMethod(ABC):
         # coo.sum_duplicates()
         # return coo.tocsr()
 
+class SharedEstimationMethod(EstimationMethod, ABC):
+    def __init__(self, index_converter: "IndexConverter"):
+        super().__init__(index_converter)
+
+        self.memory_manager = None
+        self.is_memory_manager_started = False
+
+    def _start_memory_manager(self):
+        if not self.is_memory_manager_started:
+            self.memory_manager = SharedMemoryManager()
+
+            self.memory_manager.start()
+
+            self.is_memory_manager_started = True
+
+    def _stop_memory_manager(self):
+        self.memory_manager.shutdown()
+
+        self.is_memory_manager_started = False
+
+    def _share(
+        self,
+        array: np.ndarray,
+    ) -> tuple[np.ndarray, shared_memory.SharedMemory]:
+
+        self._start_memory_manager()
+
+        array_sm = self.memory_manager.SharedMemory(array.nbytes)
+        array_shared = np.ndarray(array.shape, array.dtype, buffer=array_sm.buf)
+        array_shared[:] = array[:]
+
+        return array_shared, array_sm
+
+    def _optionally_share(self,
+                          array: np.ndarray,
+                          shared: bool = True
+        ) -> tuple[np.ndarray, shared_memory.SharedMemory | None]:
+
+        if shared:
+            return self._share(array)
+        else:
+            return array, None
 
 class SingleSample(EstimationMethod):
     """A single sample from the noise count posterior"""
@@ -701,6 +745,394 @@ class MultipleChoiceKnapsack(EstimationMethod):
         # The MAP already has the noise offsets, so they are not added to steps_csr.
         return map_csr + steps_csr
 
+class MultipleChoiceKnapsackFast(SharedEstimationMethod):
+    @staticmethod
+    def densify_without_zero_rows(coo: sp.coo_array) -> tuple[np.ndarray, np.ndarray]:
+        nonzero_rows_ = np.unique(coo.row)
+        row_map = {r: i for i, r in enumerate(nonzero_rows_)}
+        rows_ = np.fromiter((row_map[r] for r in coo.row), dtype=np.int32, count=coo.nnz)
+        dense = np.zeros((len(nonzero_rows_), coo.shape[1]), dtype=coo.dtype)
+        dense[rows_, coo.col] = coo.data
+        return dense, nonzero_rows_
+
+    @staticmethod
+    def _estimate_shared(
+        unique_genes,
+        start_idx,
+        counts,
+        n_sorted,
+        c_sorted,
+        data_sorted,
+        noise_targets_per_gene,
+        n_cells,
+        n_genes,
+        n_c,
+        bissa_dtype,
+        i,
+        n_processes,
+        nnz_genes,
+        return_array=None,
+    ):
+
+        chunk_size = int(nnz_genes / n_processes)
+        chunk_start = chunk_size * i
+        chunk_end = chunk_start + chunk_size - 1 if i != n_processes - 1 else nnz_genes
+
+        # out_data, out_row_indices, out_col_indices = MultipleChoiceKnapsackBISSA._bissa(
+        ret = MultipleChoiceKnapsackFast._estimate(
+            np.ndarray(unique_genes[0], dtype=unique_genes[1], buffer=unique_genes[2].buf)[chunk_start:chunk_end],
+            np.ndarray(start_idx[0], dtype=start_idx[1], buffer=start_idx[2].buf)[chunk_start:chunk_end],
+            np.ndarray(counts[0], dtype=counts[1], buffer=counts[2].buf)[chunk_start:chunk_end],
+            np.ndarray(n_sorted[0], dtype=n_sorted[1], buffer=n_sorted[2].buf),
+            np.ndarray(c_sorted[0], dtype=c_sorted[1], buffer=c_sorted[2].buf),
+            np.ndarray(data_sorted[0], dtype=data_sorted[1], buffer=data_sorted[2].buf),
+            np.ndarray(
+                noise_targets_per_gene[0], dtype=noise_targets_per_gene[1], buffer=noise_targets_per_gene[2].buf
+            ),
+            n_cells,
+            n_genes,
+            n_c,
+            bissa_dtype,
+            return_csr=return_array is None,
+        )
+
+        if return_array is not None:
+            return_array = np.ndarray(return_array[0], dtype=return_array[1], buffer=return_array[2].buf)
+
+            return_array[i, 0, :] = np.resize(ret[0], return_array.shape[2])
+            return_array[i, 1, :] = np.resize(ret[1], return_array.shape[2])
+            return_array[i, 2, :] = np.resize(ret[2], return_array.shape[2])
+
+            return None
+        else:
+            return ret
+
+    @staticmethod
+    def _estimate(
+        unique_genes,
+        start_idx,
+        counts,
+        n_sorted,
+        c_sorted,
+        data_sorted,
+        noise_targets_per_gene,
+        n_cells,
+        n_genes,
+        n_c,
+        bissa_dtype,
+        return_csr=True,
+    ):
+        # TODO: preallocate ndarrays
+        out_data = []
+        out_row_indices = []
+        out_col_indices = []
+
+        for gene_idx, start, count in zip(unique_genes, start_idx, counts):
+            # logger.info(f"Processing gene index {gene_idx} out of {n_genes}")
+
+            # TODO: match rounding with original if possible
+            # TODO: fix other small inconsistencies
+            noise_target = np.int32(noise_targets_per_gene[gene_idx])
+
+            end = start + count
+
+            gene_n = n_sorted[start:end]
+            gene_c = c_sorted[start:end]
+            gene_data = data_sorted[start:end]
+
+            gene_coo = sp.coo_array((gene_data, (gene_n, gene_c)), shape=(n_cells, n_c), dtype=bissa_dtype)
+
+            gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_coo)
+
+            map_argmax = np.argmax(gene_nonzero, axis=1)
+            # map = gene_nonzero[np.arange(gene_nonzero.shape[0]), map_argmax]
+
+            additional_noise_counts = noise_target - np.sum(map_argmax)
+
+            step_direction = np.sign(additional_noise_counts)
+
+            if step_direction == 0:
+                # Target == MAP
+                gene_noise_counts = map_argmax
+            elif step_direction > 0:
+                # Target > MAP
+
+                # print("step+")
+
+                max_c_idx = gene_nonzero.shape[1] - 1
+
+                while True:
+                    delta_argmax = map_argmax + 1
+
+                    overflowed_rows_mask = delta_argmax > max_c_idx
+
+                    delta_argmax = np.minimum(delta_argmax, max_c_idx)
+
+                    delta_rewards = gene_nonzero[np.arange(gene_nonzero.shape[0]), delta_argmax]
+
+                    delta_rewards[overflowed_rows_mask] = -np.inf
+
+                    topk_reward_values, topk_reward_indices = torch.topk(
+                        torch.from_numpy(delta_rewards),
+                        k=np.minimum(additional_noise_counts, delta_rewards.shape[0]),
+                        largest=True,
+                        sorted=False,
+                    )
+                    topk_reward_values = topk_reward_values.numpy()
+                    topk_reward_indices = topk_reward_indices.numpy()
+
+                    if np.any((topk_reward_values == 0.0) | (topk_reward_values == -np.inf)):
+                        # print("not enough extra possible counts")
+                        topk_reward_indices = topk_reward_indices[
+                            ~((topk_reward_values == 0.0) | (topk_reward_values == -np.inf))
+                        ]
+
+                        map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                        gene_noise_counts = map_argmax
+
+                        break
+
+                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
+                        gene_noise_counts = map_argmax
+                        # gene_noise_counts = np.zeros_like(map_argmax)
+                        # print("break")
+
+                        break
+                    else:
+                        if np.all(delta_argmax == max_c_idx):
+                            # target not achievable with all noise counts maxed
+                            # print("impossible break")
+                            gene_noise_counts = map_argmax
+                            # gene_noise_counts = np.zeros_like(map_argmax)
+
+                            break
+                        else:
+                            additional_noise_counts = noise_target - np.sum(map_argmax)
+                            # print("loop")
+
+            elif step_direction < 0:
+                # Target < MAP
+                # print("step-")
+
+                # gene_noise_counts = np.zeros_like(map_argmax)
+
+                while True:
+                    delta_argmax = map_argmax - 1
+
+                    underflowed_rows_mask = delta_argmax < 0
+
+                    delta_argmax = np.maximum(delta_argmax, 0)
+
+                    delta_rewards = gene_nonzero[np.arange(gene_nonzero.shape[0]), delta_argmax]
+
+                    delta_rewards[underflowed_rows_mask] = -np.inf
+
+                    topk_reward_values, topk_reward_indices = torch.topk(
+                        torch.from_numpy(delta_rewards),
+                        k=np.minimum(-additional_noise_counts, delta_rewards.shape[0]),
+                        largest=True,
+                        sorted=False,
+                    )
+
+                    # TODO: check for invalid topk_reward_values as above
+
+                    # topk_reward_values = topk_reward_values.numpy()
+                    topk_reward_indices = topk_reward_indices.numpy()
+
+                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
+                        gene_noise_counts = map_argmax
+                        # print("break")
+
+                        break
+                    else:
+                        if np.all(delta_argmax == 0):
+                            # target not achievable with all noise counts at min
+                            # print("impossible break")
+                            gene_noise_counts = map_argmax
+
+                            break
+                        else:
+                            additional_noise_counts = noise_target - np.sum(map_argmax)
+                            # print("loop")
+
+            if np.count_nonzero(gene_noise_counts) != 0:
+                out_data.extend(gene_noise_counts)
+                out_row_indices.extend(nonzero_rows)
+                out_col_indices.extend([gene_idx] * len(nonzero_rows))
+
+                # logger.debug("added col")
+
+        # TODO: verify that genes are in the correct order
+
+        if return_csr:
+            out_coo = sp.coo_matrix((out_data, (out_row_indices, out_col_indices)), shape=(n_cells, n_genes))
+
+            out_csr = sp.csr_matrix(out_coo)
+            out_csr.eliminate_zeros()
+
+            return out_csr
+        else:
+            return (
+                np.array(out_data, dtype=np.int32),
+                np.array(out_row_indices, dtype=np.int32),
+                np.array(out_col_indices, dtype=np.int32),
+            )
+
+    def estimate_noise(
+        self,
+        noise_log_prob_coo: sp.coo_matrix,
+        noise_offsets: Optional[Dict[int, int]],
+        noise_targets_per_gene: np.ndarray | None = None,
+        verbose: bool = False,
+        n_chunks: Optional[int] = None,
+        use_multiple_processes: bool = False,
+        **kwargs,
+    ) -> sp.csr_matrix:
+
+        # TODO: handle noise_offsets
+
+        bissa_dtype = np.float64
+
+        t0 = time.time()
+
+        coo = noise_log_prob_coo.copy()
+
+        coo.data = coo.data - (np.floor(coo.data.min()) - 1)
+
+        n_cells = self.index_converter.total_n_cells
+        n_genes = self.index_converter.total_n_genes
+        n_c = coo.shape[1]
+
+        n, g = self.index_converter.get_ng_indices(m_inds=coo.row)
+        # TODO: check the effect of changing index dtypes
+        # n = np.asarray(n, dtype=np.int32)
+        # g = np.asarray(g, dtype=np.int32)
+        # c = np.asarray(coo.col, dtype=np.int32)
+        # data = np.asarray(coo.data, dtype=bissa_dtype)
+        c = coo.col
+        data = coo.data
+
+        """
+        n_g = np.stack([n, g]).T
+        n_unique_n_g_pairs = np.unique(np.sort(n_g, axis=1), axis=0)
+        # = 19417485
+        # this is very slow to calculate and probably way too high
+        """
+
+        order = np.argsort(g, kind="mergesort")  # not sure if we need the mergesort for stability
+        g_sorted = g[order]
+        n_sorted, n_sorted_sm = self._optionally_share(n[order], use_multiple_processes)
+        c_sorted, c_sorted_sm = self._optionally_share(c[order], use_multiple_processes)
+        data_sorted, data_sorted_sm = self._optionally_share(data[order], use_multiple_processes)
+
+        unique_genes, start_idx, counts = np.unique(g_sorted, return_index=True, return_counts=True)
+
+        unique_genes, unique_genes_sm = self._optionally_share(unique_genes, use_multiple_processes)
+        start_idx, start_idx_sm = self._optionally_share(start_idx, use_multiple_processes)
+        counts, counts_sm = self._optionally_share(counts, use_multiple_processes)
+
+        noise_targets_per_gene, noise_targets_per_gene_sm = self._optionally_share(
+            noise_targets_per_gene, use_multiple_processes
+        )
+
+        t_prep = time.time()
+
+        logger.info(f"{timestamp()} fast-mckp prep time = {(t_prep - t0):.2f} sec")
+
+        if use_multiple_processes:
+            # number of p-core threads (12) is fastest, uses ~10GB of peak memory, similar to noise target compute usage
+            # number of p-cores (6) is slightly slower, uses ~14GB of peak memory
+            # number of p-core + e-core threads (20 == mp.cpu_count()) is a couple seconds slower, uses ~17GB of peak mem
+            # this info is hard to get programmatically without obscure hacks, and there is no library support
+            # effects recent Intel and Apple CPUs
+
+            # n_processes = mp.cpu_count()
+            n_processes = 12
+
+            # TODO: preallocating return arrays didn't increase speed
+
+            nonzero_upper_bound = 20000000
+
+            process_nonzero_upper_bound = int(nonzero_upper_bound / n_processes)
+
+            return_array, return_array_sm = self._optionally_share(
+                np.zeros(shape=(n_processes, 3, process_nonzero_upper_bound), dtype=np.int32)
+            )
+
+            futures = []
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=n_processes, mp_context=mp.get_context("spawn")
+            ) as executor:
+                for i in range(n_processes):
+                    kwargs = {
+                        "unique_genes": (unique_genes.shape, unique_genes.dtype, unique_genes_sm),
+                        "start_idx": (start_idx.shape, start_idx.dtype, start_idx_sm),
+                        "counts": (counts.shape, counts.dtype, counts_sm),
+                        "n_sorted": (n_sorted.shape, n_sorted.dtype, n_sorted_sm),
+                        "c_sorted": (c_sorted.shape, c_sorted.dtype, c_sorted_sm),
+                        "data_sorted": (data_sorted.shape, data_sorted.dtype, data_sorted_sm),
+                        "noise_targets_per_gene": (
+                            noise_targets_per_gene.shape,
+                            noise_targets_per_gene.dtype,
+                            noise_targets_per_gene_sm,
+                        ),
+                        "n_cells": n_cells,
+                        "n_genes": n_genes,
+                        "n_c": n_c,
+                        "bissa_dtype": bissa_dtype,
+                        "i": i,
+                        "n_processes": n_processes,
+                        "nnz_genes": unique_genes.size,
+                        # "return_array": (return_array.shape, return_array.dtype, return_array_sm),
+                        "return_array": None,
+                    }
+                    future = executor.submit(MultipleChoiceKnapsackFast._estimate_shared, **kwargs)
+                    futures.append(future)
+
+                done, not_done = concurrent.futures.wait(
+                    futures,
+                    return_when=concurrent.futures.ALL_COMPLETED,
+                )
+                csr_matrices = [f.result() for f in futures]
+
+            """
+            result = return_array.transpose(1, 0, 2).reshape(3, n_processes * process_nonzero_upper_bound)
+
+            out_csr = sp.csr_matrix((result[0], (result[1], result[2])), shape=(n_cells, n_genes)).copy()
+            out_csr.eliminate_zeros()
+            """
+
+            self._stop_memory_manager()
+
+            out_csr = sum(csr_matrices)
+        else:
+            bissa_results = MultipleChoiceKnapsackFast._estimate(
+                unique_genes,
+                start_idx,
+                counts,
+                n_sorted,
+                c_sorted,
+                data_sorted,
+                noise_targets_per_gene,
+                n_cells,
+                n_genes,
+                n_c,
+                bissa_dtype,
+            )
+
+            out_csr = bissa_results
+
+        logger.info(f"{timestamp()} fast-mckp estimation time after prep = {(time.time() - t_prep):.2f} sec")
+        logger.info(f"{timestamp()} Total fast-mckp estimation time = {(time.time() - t0):.2f} sec")
+
+        # sp.save_npz("bissa_csr_v2.npz", out_csr)
+
+        return out_csr
 
 def chunked_iterator(
     coo: sp.coo_matrix, max_dense_batch_size_GB: float = 1.0

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -185,15 +185,15 @@ class Mean(EstimationMethod):
 
         t0 = time.time()
 
-        c = torch.from_numpy(noise_log_prob_coo.col).to(device=device)
+        c = torch.from_numpy(noise_log_prob_coo.col).to(device)
 
-        data = torch.from_numpy(noise_log_prob_coo.data).to(device=device, copy=True)
+        data = torch.from_numpy(noise_log_prob_coo.data).to(device, copy=True)
         torch.exp(data, out=data)
 
         # Indices are grouped by m.
         # group_indices is an array of length m that indexes into _ = torch.unique(m) such that _[group_indices] == m.
         _, group_indices, group_sizes = torch.unique(
-            torch.from_numpy(noise_log_prob_coo.row).to(device=device), return_inverse=True, return_counts=True
+            torch.from_numpy(noise_log_prob_coo.row).to(device), return_inverse=True, return_counts=True
         )
 
         # Gets the mean for each group.
@@ -204,29 +204,25 @@ class Mean(EstimationMethod):
         # Since group_means is ordered the same as torch.unique(m), we can invert it.
         data_out = group_means[group_indices]
 
-        if noise_offsets is not None:
-            noise_offsets_n, noise_offsets_g = (
-                self.index_converter.get_ng_indices(m_inds=np.fromiter(noise_offsets.keys(), dtype=np.int64))
-            )
-        else:
-            noise_offsets_n, noise_offsets_g = None, None
-
-        new_return = sp.csr_matrix(
-            (data_out.numpy(force=True) if device == "cuda" else data_out,
-             self.index_converter.get_ng_indices(noise_log_prob_coo.row)),
+        noise_count_csr = sp.csr_matrix(
+            (data_out.numpy(force=True), self.index_converter.get_ng_indices(noise_log_prob_coo.row)),
             shape=self.index_converter.matrix_shape,
             dtype=np.float32,
         )
 
         if noise_offsets is not None:
-            new_return[noise_offsets_n, noise_offsets_g] += np.fromiter(noise_offsets.values(), dtype=np.int64)
+            noise_offsets_n, noise_offsets_g = (
+                self.index_converter.get_ng_indices(m_inds=np.fromiter(noise_offsets.keys(), dtype=np.int64))
+            )
 
-        new_return.eliminate_zeros()
-        new_return.sum_duplicates()
+            noise_count_csr[noise_offsets_n, noise_offsets_g] += np.fromiter(noise_offsets.values(), dtype=np.int64)
+
+        noise_count_csr.eliminate_zeros()
+        noise_count_csr.sum_duplicates()
 
         logger.info(f"Mean.estimate_noise(): time = {(time.time() - t0):.2f} sec")
 
-        return new_return
+        return noise_count_csr
 
 class MAP(EstimationMethod):
     """The canonical maximum a posteriori"""

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -14,8 +14,10 @@ if TYPE_CHECKING:
     from cellbender.remove_background.posterior import IndexConverter
 
 import numpy as np
+import cupy as cp
 import pandas as pd
 import scipy.sparse as sp
+import cupyx.scipy.sparse as cusp
 import torch
 from torch.distributions.categorical import Categorical
 
@@ -747,12 +749,18 @@ class MultipleChoiceKnapsack(EstimationMethod):
 
 class MultipleChoiceKnapsackFast(SharedEstimationMethod):
     @staticmethod
-    def densify_without_zero_rows(coo: sp.coo_array) -> tuple[np.ndarray, np.ndarray]:
-        nonzero_rows_ = np.unique(coo.row)
-        row_map = {r: i for i, r in enumerate(nonzero_rows_)}
-        rows_ = np.fromiter((row_map[r] for r in coo.row), dtype=np.int32, count=coo.nnz)
-        dense = np.zeros((len(nonzero_rows_), coo.shape[1]), dtype=coo.dtype)
+    def densify_without_zero_rows(coo: sp.coo_array | cusp.coo_matrix) -> tuple[np.ndarray | cp.ndarray, np.ndarray | cp.ndarray]:
+        # TODO: Claude made this, I'm not sure how or if it works.
+
+        xp = cp.get_array_module(coo.row)
+
+        nonzero_rows_ = xp.unique(coo.row)
+
+        rows_ = xp.searchsorted(nonzero_rows_, coo.row)
+
+        dense = xp.zeros((len(nonzero_rows_), coo.shape[1]), dtype=coo.dtype)
         dense[rows_, coo.col] = coo.data
+
         return dense, nonzero_rows_
 
     @staticmethod
@@ -767,7 +775,8 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
         n_cells,
         n_genes,
         n_c,
-        bissa_dtype,
+        data_dtype,
+        index_dtype,
         i,
         n_processes,
         nnz_genes,
@@ -778,7 +787,7 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
         chunk_start = chunk_size * i
         chunk_end = chunk_start + chunk_size - 1 if i != n_processes - 1 else nnz_genes
 
-        # out_data, out_row_indices, out_col_indices = MultipleChoiceKnapsackBISSA._bissa(
+        # out_data, out_row_indices, out_col_indices = MultipleChoiceKnapsackFast._estimate(
         ret = MultipleChoiceKnapsackFast._estimate(
             np.ndarray(unique_genes[0], dtype=unique_genes[1], buffer=unique_genes[2].buf)[chunk_start:chunk_end],
             np.ndarray(start_idx[0], dtype=start_idx[1], buffer=start_idx[2].buf)[chunk_start:chunk_end],
@@ -792,7 +801,9 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
             n_cells,
             n_genes,
             n_c,
-            bissa_dtype,
+            data_dtype,
+            index_dtype,
+            use_gpu=False,
             return_csr=return_array is None,
         )
 
@@ -819,7 +830,9 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
         n_cells,
         n_genes,
         n_c,
-        bissa_dtype,
+        data_dtype,
+        index_dtype,
+        use_gpu,
         return_csr=True,
     ):
         # TODO: preallocate ndarrays
@@ -827,12 +840,15 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
         out_row_indices = []
         out_col_indices = []
 
+        xp = cp.get_array_module(unique_genes)
+
         for gene_idx, start, count in zip(unique_genes, start_idx, counts):
             # logger.info(f"Processing gene index {gene_idx} out of {n_genes}")
 
             # TODO: match rounding with original if possible
             # TODO: fix other small inconsistencies
-            noise_target = np.int32(noise_targets_per_gene[gene_idx])
+            #noise_target = int(noise_targets_per_gene[gene_idx])
+            noise_target = xp.floor(noise_targets_per_gene[gene_idx])
 
             end = start + count
 
@@ -840,16 +856,27 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
             gene_c = c_sorted[start:end]
             gene_data = data_sorted[start:end]
 
-            gene_coo = sp.coo_array((gene_data, (gene_n, gene_c)), shape=(n_cells, n_c), dtype=bissa_dtype)
+            # TODO: map coords without constructing the matrix objects
+            if use_gpu:
+                gene_coo = cusp.coo_matrix((gene_data, (gene_n, gene_c)),
+                                           shape=(gene_n.max() + 1, gene_c.max() + 1),
+                                           dtype=data_dtype)
 
-            gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_coo)
+                gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_coo)
 
-            map_argmax = np.argmax(gene_nonzero, axis=1)
-            # map = gene_nonzero[np.arange(gene_nonzero.shape[0]), map_argmax]
+                map_argmax = xp.argmax(gene_nonzero, axis=1, dtype=index_dtype)
+            else:
+                gene_coo = sp.coo_array((gene_data, (gene_n, gene_c)),
+                                        shape=(gene_n.max() + 1, gene_c.max() + 1),
+                                        dtype=data_dtype)
 
-            additional_noise_counts = noise_target - np.sum(map_argmax)
+                gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_coo)
 
-            step_direction = np.sign(additional_noise_counts)
+                map_argmax = xp.argmax(gene_nonzero, axis=1).astype(index_dtype)
+
+            additional_noise_counts = noise_target - xp.sum(map_argmax, dtype=data_dtype)
+
+            step_direction = xp.sign(additional_noise_counts)
 
             if step_direction == 0:
                 # Target == MAP
@@ -866,25 +893,36 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
 
                     overflowed_rows_mask = delta_argmax > max_c_idx
 
-                    delta_argmax = np.minimum(delta_argmax, max_c_idx)
+                    delta_argmax = xp.minimum(delta_argmax, max_c_idx)
 
-                    delta_rewards = gene_nonzero[np.arange(gene_nonzero.shape[0]), delta_argmax]
+                    delta_rewards = gene_nonzero[xp.arange(gene_nonzero.shape[0]), delta_argmax]
 
-                    delta_rewards[overflowed_rows_mask] = -np.inf
+                    delta_rewards[overflowed_rows_mask] = -xp.inf
 
-                    topk_reward_values, topk_reward_indices = torch.topk(
-                        torch.from_numpy(delta_rewards),
-                        k=np.minimum(additional_noise_counts, delta_rewards.shape[0]),
-                        largest=True,
-                        sorted=False,
-                    )
-                    topk_reward_values = topk_reward_values.numpy()
-                    topk_reward_indices = topk_reward_indices.numpy()
+                    if use_gpu:
+                        #TODO: maybe switch to xp.partition
+                        topk_reward_values, topk_reward_indices = torch.topk(
+                            torch.as_tensor(delta_rewards, device='cuda'),
+                            k=int(xp.minimum(additional_noise_counts, delta_rewards.shape[0])),
+                            largest=True,
+                            sorted=False,
+                        )
+                        topk_reward_values = cp.asarray(topk_reward_values)
+                        topk_reward_indices = cp.asarray(topk_reward_indices)
+                    else:
+                        topk_reward_values, topk_reward_indices = torch.topk(
+                            torch.from_numpy(delta_rewards),
+                            k=int(np.minimum(additional_noise_counts, delta_rewards.shape[0])),
+                            largest=True,
+                            sorted=False,
+                        )
+                        topk_reward_values = topk_reward_values.numpy()
+                        topk_reward_indices = topk_reward_indices.numpy()
 
-                    if np.any((topk_reward_values == 0.0) | (topk_reward_values == -np.inf)):
+                    if xp.any((topk_reward_values == 0.0) | (topk_reward_values == -xp.inf)):
                         # print("not enough extra possible counts")
                         topk_reward_indices = topk_reward_indices[
-                            ~((topk_reward_values == 0.0) | (topk_reward_values == -np.inf))
+                            ~((topk_reward_values == 0.0) | (topk_reward_values == -xp.inf))
                         ]
 
                         map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
@@ -897,50 +935,59 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
 
                     if map_argmax.sum() == noise_target:  # probly inconsistent rounding
                         gene_noise_counts = map_argmax
-                        # gene_noise_counts = np.zeros_like(map_argmax)
                         # print("break")
 
                         break
                     else:
-                        if np.all(delta_argmax == max_c_idx):
+                        if xp.all(delta_argmax == max_c_idx):
                             # target not achievable with all noise counts maxed
                             # print("impossible break")
                             gene_noise_counts = map_argmax
-                            # gene_noise_counts = np.zeros_like(map_argmax)
 
                             break
                         else:
-                            additional_noise_counts = noise_target - np.sum(map_argmax)
+                            additional_noise_counts = noise_target - xp.sum(map_argmax)
                             # print("loop")
 
             elif step_direction < 0:
                 # Target < MAP
                 # print("step-")
 
-                # gene_noise_counts = np.zeros_like(map_argmax)
-
                 while True:
                     delta_argmax = map_argmax - 1
 
                     underflowed_rows_mask = delta_argmax < 0
 
-                    delta_argmax = np.maximum(delta_argmax, 0)
+                    delta_argmax = xp.maximum(delta_argmax, 0)
 
-                    delta_rewards = gene_nonzero[np.arange(gene_nonzero.shape[0]), delta_argmax]
+                    delta_rewards = gene_nonzero[xp.arange(gene_nonzero.shape[0]), delta_argmax]
 
-                    delta_rewards[underflowed_rows_mask] = -np.inf
+                    delta_rewards[underflowed_rows_mask] = -xp.inf
 
-                    topk_reward_values, topk_reward_indices = torch.topk(
-                        torch.from_numpy(delta_rewards),
-                        k=np.minimum(-additional_noise_counts, delta_rewards.shape[0]),
-                        largest=True,
-                        sorted=False,
-                    )
+                    if use_gpu:
+                        topk_reward_values, topk_reward_indices = torch.topk(
+                            torch.as_tensor(delta_rewards, device='cuda'),
+                            k=int(xp.minimum(-additional_noise_counts, delta_rewards.shape[0])),
+                            largest=True,
+                            sorted=False,
+                        )
 
-                    # TODO: check for invalid topk_reward_values as above
+                        # TODO: check for invalid topk_reward_values as above
 
-                    # topk_reward_values = topk_reward_values.numpy()
-                    topk_reward_indices = topk_reward_indices.numpy()
+                        #topk_reward_values = cp.asarray(topk_reward_values)
+                        topk_reward_indices = cp.asarray(topk_reward_indices)
+                    else:
+                        topk_reward_values, topk_reward_indices = torch.topk(
+                            torch.from_numpy(delta_rewards),
+                            k=int(np.minimum(-additional_noise_counts, delta_rewards.shape[0])),
+                            largest=True,
+                            sorted=False,
+                        )
+
+                        # TODO: check for invalid topk_reward_values as above
+
+                        #topk_reward_values = topk_reward_values.numpy()
+                        topk_reward_indices = topk_reward_indices.numpy()
 
                     map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
 
@@ -950,20 +997,20 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
 
                         break
                     else:
-                        if np.all(delta_argmax == 0):
+                        if xp.all(delta_argmax == 0):
                             # target not achievable with all noise counts at min
                             # print("impossible break")
                             gene_noise_counts = map_argmax
 
                             break
                         else:
-                            additional_noise_counts = noise_target - np.sum(map_argmax)
+                            additional_noise_counts = noise_target - xp.sum(map_argmax)
                             # print("loop")
 
-            if np.count_nonzero(gene_noise_counts) != 0:
-                out_data.extend(gene_noise_counts)
-                out_row_indices.extend(nonzero_rows)
-                out_col_indices.extend([gene_idx] * len(nonzero_rows))
+            if xp.count_nonzero(gene_noise_counts) != 0:
+                out_data.extend(gene_noise_counts.get() if use_gpu else gene_noise_counts)
+                out_row_indices.extend(nonzero_rows.get() if use_gpu else nonzero_rows)
+                out_col_indices.extend([gene_idx.get() if use_gpu else gene_idx] * len(nonzero_rows))
 
                 # logger.debug("added col")
 
@@ -996,55 +1043,117 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
 
         # TODO: handle noise_offsets
 
-        bissa_dtype = np.float64
-
         t0 = time.time()
 
-        coo = noise_log_prob_coo.copy()
+        setup_gpu = True
+        use_gpu = False
 
-        coo.data = coo.data - (np.floor(coo.data.min()) - 1)
+        if use_gpu:
+            assert setup_gpu
+            assert not use_multiple_processes #TODO: try to make this work, but it will probably be even slower
 
-        n_cells = self.index_converter.total_n_cells
-        n_genes = self.index_converter.total_n_genes
-        n_c = coo.shape[1]
+        data_dtype = np.float32
+        index_dtype = np.int32 # TODO: check the effect of changing index dtypes
 
-        n, g = self.index_converter.get_ng_indices(m_inds=coo.row)
-        # TODO: check the effect of changing index dtypes
-        # n = np.asarray(n, dtype=np.int32)
-        # g = np.asarray(g, dtype=np.int32)
-        # c = np.asarray(coo.col, dtype=np.int32)
-        # data = np.asarray(coo.data, dtype=bissa_dtype)
-        c = coo.col
-        data = coo.data
+        if setup_gpu:
+            # Do an example CuPy computation to measure CUDA context initialization time.
+            # Actually, init may happen in get_ng_indices upon calling cp.get_array_module, not sure.
+            t_cuda_init_start = time.time()
 
-        """
-        n_g = np.stack([n, g]).T
-        n_unique_n_g_pairs = np.unique(np.sort(n_g, axis=1), axis=0)
-        # = 19417485
-        # this is very slow to calculate and probably way too high
-        """
+            x_gpu = cp.array([1, 2, 3])
+            l2_gpu = cp.linalg.norm(x_gpu)
+            print(l2_gpu)
 
-        order = np.argsort(g, kind="mergesort")  # not sure if we need the mergesort for stability
-        g_sorted = g[order]
-        n_sorted, n_sorted_sm = self._optionally_share(n[order], use_multiple_processes)
-        c_sorted, c_sorted_sm = self._optionally_share(c[order], use_multiple_processes)
-        data_sorted, data_sorted_sm = self._optionally_share(data[order], use_multiple_processes)
+            t_cuda_init_end = time.time()
 
-        unique_genes, start_idx, counts = np.unique(g_sorted, return_index=True, return_counts=True)
+            logger.info(f"{timestamp()} cuda init time = {(t_cuda_init_end - t_cuda_init_start):.2f} sec")
 
-        unique_genes, unique_genes_sm = self._optionally_share(unique_genes, use_multiple_processes)
-        start_idx, start_idx_sm = self._optionally_share(start_idx, use_multiple_processes)
-        counts, counts_sm = self._optionally_share(counts, use_multiple_processes)
+            data = cp.asarray(noise_log_prob_coo.data, dtype=data_dtype)
 
-        noise_targets_per_gene, noise_targets_per_gene_sm = self._optionally_share(
-            noise_targets_per_gene, use_multiple_processes
-        )
+            data = data - (np.floor(data.min()) - 1)
 
-        t_prep = time.time()
+            n_cells = self.index_converter.total_n_cells
+            n_genes = self.index_converter.total_n_genes
+            n_c = noise_log_prob_coo.shape[1]
 
-        logger.info(f"{timestamp()} fast-mckp prep time = {(t_prep - t0):.2f} sec")
+            n, g = self.index_converter.get_ng_indices(m_inds=cp.asarray(noise_log_prob_coo.row))
+            n = n.astype(index_dtype)
+            g = g.astype(index_dtype)
+            c = cp.asarray(noise_log_prob_coo.col, dtype=index_dtype)
+
+            order = cp.argsort(g).astype(index_dtype)  # does not support kind="mergesort", should be stable by default
+            g_sorted = g[order]
+            n_sorted = n[order]
+            c_sorted = c[order]
+            data_sorted = data[order]
+
+            unique_genes, start_idx, counts = cp.unique(g_sorted, return_index=True, return_counts=True)
+
+            start_idx = start_idx.astype(index_dtype)
+            counts = counts.astype(index_dtype)
+
+            noise_targets_per_gene = cp.asarray(noise_targets_per_gene, dtype=data_dtype)
+        else:
+            data = noise_log_prob_coo.data
+
+            data = data - (np.floor(data.min()) - 1)
+
+            n_cells = self.index_converter.total_n_cells
+            n_genes = self.index_converter.total_n_genes
+            n_c = noise_log_prob_coo.shape[1]
+
+            n, g = self.index_converter.get_ng_indices(m_inds=noise_log_prob_coo.row)
+            n = n.astype(index_dtype)
+            g = g.astype(index_dtype)
+            c = noise_log_prob_coo.col.astype(index_dtype)
+
+            # not sure if we need the mergesort for stability
+            order = np.argsort(g, kind="mergesort").astype(index_dtype)
+            g_sorted = g[order]
+            n_sorted, n_sorted_sm = self._optionally_share(n[order], use_multiple_processes)
+            c_sorted, c_sorted_sm = self._optionally_share(c[order], use_multiple_processes)
+            data_sorted, data_sorted_sm = self._optionally_share(data[order], use_multiple_processes)
+
+            unique_genes, start_idx, counts = np.unique(g_sorted, return_index=True, return_counts=True)
+
+            unique_genes, unique_genes_sm = self._optionally_share(unique_genes, use_multiple_processes)
+            start_idx, start_idx_sm = self._optionally_share(start_idx.astype(index_dtype), use_multiple_processes)
+            counts, counts_sm = self._optionally_share(counts.astype(index_dtype), use_multiple_processes)
+
+            noise_targets_per_gene, noise_targets_per_gene_sm = self._optionally_share(
+                noise_targets_per_gene.astype(data_dtype), use_multiple_processes
+            )
+
+        # Yes, it is actually faster to load and unload everything off the GPU and copy it all into shared memory.
+        if setup_gpu and not use_gpu:
+            n_sorted = n_sorted.get()
+            c_sorted = c_sorted.get()
+            data_sorted = data_sorted.get()
+
+            unique_genes = unique_genes.get()
+            start_idx = start_idx.get()
+            counts = counts.get()
+
+            noise_targets_per_gene = noise_targets_per_gene.get()
+
+            if use_multiple_processes:
+                n_sorted, n_sorted_sm = self._share(n_sorted)
+                c_sorted, c_sorted_sm = self._share(c_sorted)
+                data_sorted, data_sorted_sm = self._share(data_sorted)
+
+                unique_genes, unique_genes_sm = self._share(unique_genes)
+                start_idx, start_idx_sm = self._share(start_idx)
+                counts, counts_sm = self._share(counts)
+
+                noise_targets_per_gene, noise_targets_per_gene_sm = self._share(noise_targets_per_gene)
+
+        t_setup = time.time()
+
+        logger.info(f"{timestamp()} fast-mckp setup time = {(t_setup - t0):.2f} sec")
 
         if use_multiple_processes:
+            #TODO: now memory usage is lower and 6 processes are faster, need to remeasure
+
             # number of p-core threads (12) is fastest, uses ~10GB of peak memory, similar to noise target compute usage
             # number of p-cores (6) is slightly slower, uses ~14GB of peak memory
             # number of p-core + e-core threads (20 == mp.cpu_count()) is a couple seconds slower, uses ~17GB of peak mem
@@ -1052,10 +1161,10 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
             # effects recent Intel and Apple CPUs
 
             # n_processes = mp.cpu_count()
-            n_processes = 12
+            n_processes = 6
 
-            # TODO: preallocating return arrays didn't increase speed
-
+            # TODO: preallocating return arrays didn't increase speed and doesn't work right
+            """
             nonzero_upper_bound = 20000000
 
             process_nonzero_upper_bound = int(nonzero_upper_bound / n_processes)
@@ -1063,7 +1172,7 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
             return_array, return_array_sm = self._optionally_share(
                 np.zeros(shape=(n_processes, 3, process_nonzero_upper_bound), dtype=np.int32)
             )
-
+            """
             futures = []
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=n_processes, mp_context=mp.get_context("spawn")
@@ -1084,11 +1193,12 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
                         "n_cells": n_cells,
                         "n_genes": n_genes,
                         "n_c": n_c,
-                        "bissa_dtype": bissa_dtype,
+                        "data_dtype": data_dtype,
+                        "index_dtype": index_dtype,
                         "i": i,
                         "n_processes": n_processes,
                         "nnz_genes": unique_genes.size,
-                        # "return_array": (return_array.shape, return_array.dtype, return_array_sm),
+                        #"return_array": (return_array.shape, return_array.dtype, return_array_sm),
                         "return_array": None,
                     }
                     future = executor.submit(MultipleChoiceKnapsackFast._estimate_shared, **kwargs)
@@ -1111,7 +1221,7 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
 
             out_csr = sum(csr_matrices)
         else:
-            bissa_results = MultipleChoiceKnapsackFast._estimate(
+            mckp_results = MultipleChoiceKnapsackFast._estimate(
                 unique_genes,
                 start_idx,
                 counts,
@@ -1122,15 +1232,17 @@ class MultipleChoiceKnapsackFast(SharedEstimationMethod):
                 n_cells,
                 n_genes,
                 n_c,
-                bissa_dtype,
+                data_dtype,
+                index_dtype,
+                use_gpu,
             )
 
-            out_csr = bissa_results
+            out_csr = mckp_results
 
-        logger.info(f"{timestamp()} fast-mckp estimation time after prep = {(time.time() - t_prep):.2f} sec")
+        logger.info(f"{timestamp()} fast-mckp estimation time after prep = {(time.time() - t_setup):.2f} sec")
         logger.info(f"{timestamp()} Total fast-mckp estimation time = {(time.time() - t0):.2f} sec")
 
-        # sp.save_npz("bissa_csr_v2.npz", out_csr)
+        # sp.save_npz("mckp_csr_v2.npz", out_csr)
 
         return out_csr
 

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -119,6 +119,35 @@ class SingleSample(EstimationMethod):
 class Mean(EstimationMethod):
     """Posterior mean"""
 
+    def estimate_noise(
+        self, noise_log_prob_coo: sp.coo_matrix, noise_offsets: Optional[Dict[int, int]], device: str = "cpu", **kwargs
+    ) -> sp.csr_matrix:
+        """Given the full probabilistic posterior, compute noise counts by
+        taking the mean of each probability distribution.
+
+        Args:
+            noise_log_prob_coo: The noise log prob data structure: log prob
+                values in a (m, c) COO matrix
+            noise_offsets: Noise count offset values keyed by 'm'.
+
+        Returns:
+            noise_count_csr: Estimated noise count matrix.
+        """
+        # c = torch.arange(noise_log_prob_coo.shape[1], dtype=float).to(device).t()
+
+        def _torch_mean(x):
+            c = torch.arange(x.shape[1], dtype=float).to(x.device)
+            return torch.matmul(x.exp(), c.t())
+
+        result = apply_function_dense_chunks(noise_log_prob_coo=noise_log_prob_coo, fun=_torch_mean, device=device)
+        return self._estimation_array_to_csr(
+            data=result["result"], m=result["m"], noise_offsets=noise_offsets, dtype=np.float32
+        )
+
+
+class MeanFast(EstimationMethod):
+    """Posterior mean"""
+
     @torch.no_grad()
     def estimate_noise(
         self, noise_log_prob_coo: sp.coo_matrix, noise_offsets: Optional[Dict[int, int]], device: str = "cpu", **kwargs

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -16,10 +16,8 @@ if TYPE_CHECKING:
     from cellbender.remove_background.posterior import IndexConverter
 
 import numpy as np
-import cupy as cp
 import pandas as pd
 import scipy.sparse as sp
-import cupyx.scipy.sparse as cusp
 import torch
 from torch.distributions.categorical import Categorical
 
@@ -806,7 +804,7 @@ def _estimate_fast_mckp(
         gene_c = c_sorted[start:end]
         gene_data = data_sorted[start:end]
 
-        gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows2(gene_data, gene_n, gene_c)
+        gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_data, gene_n, gene_c)
 
         map_argmax = torch.argmax(gene_nonzero, dim=1)
 
@@ -837,7 +835,6 @@ def _estimate_fast_mckp(
 
                 delta_rewards[overflowed_rows_mask] = -torch.inf
 
-                # TODO: maybe switch to xp.partition
                 topk_reward_values, topk_reward_indices = torch.topk(
                     delta_rewards,
                     k=int(torch.minimum(additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
@@ -952,26 +949,6 @@ class MultipleChoiceKnapsackFast(EstimationMethod):
     @staticmethod
     @torch.no_grad()
     def densify_without_zero_rows(
-        coo: sp.coo_array | cusp.coo_matrix,
-        dtype: torch.dtype,
-        device: str,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        # TODO: Claude made this, I'm not sure how or if it works.
-
-        coo_row = torch.from_numpy(coo.row).to(device)
-
-        nonzero_rows_ = torch.unique(coo_row)
-
-        rows_ = torch.searchsorted(nonzero_rows_, coo_row)
-
-        dense = torch.zeros((len(nonzero_rows_), coo.shape[1]), dtype=dtype)
-        dense[rows_, torch.from_numpy(coo.col).to(device)] = torch.from_numpy(coo.data).to(device)
-
-        return dense, nonzero_rows_
-
-    @staticmethod
-    @torch.no_grad()
-    def densify_without_zero_rows2(
         data,
         row,
         col,

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -91,49 +91,6 @@ class EstimationMethod(ABC):
         # coo.sum_duplicates()
         # return coo.tocsr()
 
-class SharedEstimationMethod(EstimationMethod, ABC):
-    def __init__(self, index_converter: "IndexConverter"):
-        super().__init__(index_converter)
-
-        self.memory_manager = None
-        self.is_memory_manager_started = False
-
-    def _start_memory_manager(self):
-        if not self.is_memory_manager_started:
-            self.memory_manager = SharedMemoryManager()
-
-            self.memory_manager.start()
-
-            self.is_memory_manager_started = True
-
-    def _stop_memory_manager(self):
-        self.memory_manager.shutdown()
-
-        self.is_memory_manager_started = False
-
-    def _share(
-        self,
-        array: np.ndarray,
-    ) -> tuple[np.ndarray, shared_memory.SharedMemory]:
-
-        self._start_memory_manager()
-
-        array_sm = self.memory_manager.SharedMemory(array.nbytes)
-        array_shared = np.ndarray(array.shape, array.dtype, buffer=array_sm.buf)
-        array_shared[:] = array[:]
-
-        return array_shared, array_sm
-
-    def _optionally_share(self,
-                          array: np.ndarray,
-                          shared: bool = True
-        ) -> tuple[np.ndarray, shared_memory.SharedMemory | None]:
-
-        if shared:
-            return self._share(array)
-        else:
-            return array, None
-
 class SingleSample(EstimationMethod):
     """A single sample from the noise count posterior"""
 
@@ -808,7 +765,7 @@ def unique_with_indices(x, sort = False, return_counts = False):
         return u, first_idx, inv
 
 @torch.no_grad()
-def _estimate_fast_mckp2(
+def _estimate_fast_mckp(
     process_index,
     gene_chunks,
     use_multiple_processes,
@@ -826,7 +783,7 @@ def _estimate_fast_mckp2(
     n_threads,
     t_start,
 ):
-    print(f"{timestamp()} fast-mckp2 process {process_index} time to start = {(time.time() - t_start):.2f} sec")
+    print(f"{timestamp()} fast-mckp process {process_index} time to start = {(time.time() - t_start):.2f} sec")
 
     t0 = time.time()
 
@@ -849,7 +806,7 @@ def _estimate_fast_mckp2(
         gene_c = c_sorted[start:end]
         gene_data = data_sorted[start:end]
 
-        gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast2.densify_without_zero_rows2(gene_data, gene_n, gene_c)
+        gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows2(gene_data, gene_n, gene_c)
 
         map_argmax = torch.argmax(gene_nonzero, dim=1)
 
@@ -984,14 +941,14 @@ def _estimate_fast_mckp2(
             shape=(total_n_cells, total_n_genes),
         )
 
-    print(f"{timestamp()} fast-mckp2 process {process_index} time = {(time.time() - t0):.2f} sec")
+    print(f"{timestamp()} fast-mckp process {process_index} time = {(time.time() - t0):.2f} sec")
 
     if use_multiple_processes:
         out_stack_queue.join()
 
     return out_csr
 
-class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
+class MultipleChoiceKnapsackFast(EstimationMethod):
     @staticmethod
     @torch.no_grad()
     def densify_without_zero_rows(
@@ -1133,7 +1090,7 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
 
         torch.cuda.empty_cache()
 
-        logger.info(f"{timestamp()} fast-mckp2 setup time = {(t_setup - t0):.2f} sec")
+        logger.info(f"{timestamp()} fast-mckp setup time = {(t_setup - t0):.2f} sec")
 
         if use_multiple_processes:
             gene_chunks = torch.arange(unique_genes.shape[0], device=device).tensor_split(n_processes)
@@ -1153,7 +1110,7 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
             t_start = time.time()
 
             process_context = torchmp.start_processes(
-                _estimate_fast_mckp2,
+                _estimate_fast_mckp,
                 args=(
                     gene_chunks,
                     use_multiple_processes,
@@ -1202,12 +1159,12 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
 
             out_csr = sum(out_csr_list)
 
-            logger.info(f"{timestamp()} fast-mckp2 collection time = {(time.time() - t_collect):.2f} sec")
+            logger.info(f"{timestamp()} fast-mckp collection time = {(time.time() - t_collect):.2f} sec")
 
         else:
             t_start = time.time()
 
-            out_csr = _estimate_fast_mckp2(
+            out_csr = _estimate_fast_mckp(
                 0,
                 torch.unsqueeze(torch.arange(unique_genes.shape[0]), dim=0),
                 use_multiple_processes,
@@ -1230,507 +1187,8 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
 
         torch.cuda.empty_cache()
 
-        logger.info(f"{timestamp()} fast-mckp2 estimation time after prep = {(time.time() - t_setup):.2f} sec")
-        logger.info(f"{timestamp()} Total fast-mckp2 estimation time = {(time.time() - t0):.2f} sec")
-
-        return out_csr
-
-class MultipleChoiceKnapsackFast(SharedEstimationMethod):
-    @staticmethod
-    def densify_without_zero_rows(coo: sp.coo_array | cusp.coo_matrix) -> tuple[np.ndarray | cp.ndarray, np.ndarray | cp.ndarray]:
-        # TODO: Claude made this, I'm not sure how or if it works.
-
-        xp = cp.get_array_module(coo.row)
-
-        nonzero_rows_ = xp.unique(coo.row)
-
-        rows_ = xp.searchsorted(nonzero_rows_, coo.row)
-
-        dense = xp.zeros((len(nonzero_rows_), coo.shape[1]), dtype=coo.dtype)
-        dense[rows_, coo.col] = coo.data
-
-        return dense, nonzero_rows_
-
-    @staticmethod
-    def _estimate_shared(
-        unique_genes,
-        start_idx,
-        counts,
-        n_sorted,
-        c_sorted,
-        data_sorted,
-        noise_targets_per_gene,
-        n_cells,
-        n_genes,
-        n_c,
-        data_dtype,
-        index_dtype,
-        i,
-        n_processes,
-        nnz_genes,
-        return_array=None,
-    ):
-
-        chunk_size = int(nnz_genes / n_processes)
-        chunk_start = chunk_size * i
-        chunk_end = chunk_start + chunk_size - 1 if i != n_processes - 1 else nnz_genes
-
-        # out_data, out_row_indices, out_col_indices = MultipleChoiceKnapsackFast._estimate(
-        ret = MultipleChoiceKnapsackFast._estimate(
-            np.ndarray(unique_genes[0], dtype=unique_genes[1], buffer=unique_genes[2].buf)[chunk_start:chunk_end],
-            np.ndarray(start_idx[0], dtype=start_idx[1], buffer=start_idx[2].buf)[chunk_start:chunk_end],
-            np.ndarray(counts[0], dtype=counts[1], buffer=counts[2].buf)[chunk_start:chunk_end],
-            np.ndarray(n_sorted[0], dtype=n_sorted[1], buffer=n_sorted[2].buf),
-            np.ndarray(c_sorted[0], dtype=c_sorted[1], buffer=c_sorted[2].buf),
-            np.ndarray(data_sorted[0], dtype=data_sorted[1], buffer=data_sorted[2].buf),
-            np.ndarray(
-                noise_targets_per_gene[0], dtype=noise_targets_per_gene[1], buffer=noise_targets_per_gene[2].buf
-            ),
-            n_cells,
-            n_genes,
-            n_c,
-            data_dtype,
-            index_dtype,
-            use_gpu=False,
-            return_csr=return_array is None,
-        )
-
-        if return_array is not None:
-            return_array = np.ndarray(return_array[0], dtype=return_array[1], buffer=return_array[2].buf)
-
-            return_array[i, 0, :] = np.resize(ret[0], return_array.shape[2])
-            return_array[i, 1, :] = np.resize(ret[1], return_array.shape[2])
-            return_array[i, 2, :] = np.resize(ret[2], return_array.shape[2])
-
-            return None
-        else:
-            return ret
-
-    @staticmethod
-    def _estimate(
-        unique_genes,
-        start_idx,
-        counts,
-        n_sorted,
-        c_sorted,
-        data_sorted,
-        noise_targets_per_gene,
-        n_cells,
-        n_genes,
-        n_c,
-        data_dtype,
-        index_dtype,
-        use_gpu,
-        return_csr=True,
-    ):
-        # TODO: preallocate ndarrays
-        out_data = []
-        out_row_indices = []
-        out_col_indices = []
-
-        xp = cp.get_array_module(unique_genes)
-
-        for gene_idx, start, count in zip(unique_genes, start_idx, counts):
-            # logger.info(f"Processing gene index {gene_idx} out of {n_genes}")
-
-            # TODO: match rounding with original if possible
-            # TODO: fix other small inconsistencies
-            #noise_target = int(noise_targets_per_gene[gene_idx])
-            noise_target = xp.floor(noise_targets_per_gene[gene_idx])
-
-            end = start + count
-
-            gene_n = n_sorted[start:end]
-            gene_c = c_sorted[start:end]
-            gene_data = data_sorted[start:end]
-
-            # TODO: map coords without constructing the matrix objects
-            if use_gpu:
-                gene_coo = cusp.coo_matrix((gene_data, (gene_n, gene_c)),
-                                           shape=(gene_n.max() + 1, gene_c.max() + 1),
-                                           dtype=data_dtype)
-
-                gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_coo)
-
-                map_argmax = xp.argmax(gene_nonzero, axis=1, dtype=index_dtype)
-            else:
-                gene_coo = sp.coo_array((gene_data, (gene_n, gene_c)),
-                                        shape=(gene_n.max() + 1, gene_c.max() + 1),
-                                        dtype=data_dtype)
-
-                gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast.densify_without_zero_rows(gene_coo)
-
-                map_argmax = xp.argmax(gene_nonzero, axis=1).astype(index_dtype)
-
-            additional_noise_counts = noise_target - xp.sum(map_argmax, dtype=data_dtype)
-
-            step_direction = xp.sign(additional_noise_counts)
-
-            if step_direction == 0:
-                # Target == MAP
-                gene_noise_counts = map_argmax
-            elif step_direction > 0:
-                # Target > MAP
-
-                # print("step+")
-
-                max_c_idx = gene_nonzero.shape[1] - 1
-
-                while True:
-                    delta_argmax = map_argmax + 1
-
-                    overflowed_rows_mask = delta_argmax > max_c_idx
-
-                    delta_argmax = xp.minimum(delta_argmax, max_c_idx)
-
-                    delta_rewards = gene_nonzero[xp.arange(gene_nonzero.shape[0]), delta_argmax]
-
-                    delta_rewards[overflowed_rows_mask] = -xp.inf
-
-                    if use_gpu:
-                        #TODO: maybe switch to xp.partition
-                        topk_reward_values, topk_reward_indices = torch.topk(
-                            torch.as_tensor(delta_rewards, device='cuda'),
-                            k=int(xp.minimum(additional_noise_counts, delta_rewards.shape[0])),
-                            largest=True,
-                            sorted=False,
-                        )
-                        topk_reward_values = cp.asarray(topk_reward_values)
-                        topk_reward_indices = cp.asarray(topk_reward_indices)
-                    else:
-                        topk_reward_values, topk_reward_indices = torch.topk(
-                            torch.from_numpy(delta_rewards),
-                            k=int(np.minimum(additional_noise_counts, delta_rewards.shape[0])),
-                            largest=True,
-                            sorted=False,
-                        )
-                        topk_reward_values = topk_reward_values.numpy()
-                        topk_reward_indices = topk_reward_indices.numpy()
-
-                    if xp.any((topk_reward_values == 0.0) | (topk_reward_values == -xp.inf)):
-                        # print("not enough extra possible counts")
-                        topk_reward_indices = topk_reward_indices[
-                            ~((topk_reward_values == 0.0) | (topk_reward_values == -xp.inf))
-                        ]
-
-                        map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
-
-                        gene_noise_counts = map_argmax
-
-                        break
-
-                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
-
-                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
-                        gene_noise_counts = map_argmax
-                        # print("break")
-
-                        break
-                    else:
-                        if xp.all(delta_argmax == max_c_idx):
-                            # target not achievable with all noise counts maxed
-                            # print("impossible break")
-                            gene_noise_counts = map_argmax
-
-                            break
-                        else:
-                            additional_noise_counts = noise_target - xp.sum(map_argmax)
-                            # print("loop")
-
-            elif step_direction < 0:
-                # Target < MAP
-                # print("step-")
-
-                while True:
-                    delta_argmax = map_argmax - 1
-
-                    underflowed_rows_mask = delta_argmax < 0
-
-                    delta_argmax = xp.maximum(delta_argmax, 0)
-
-                    delta_rewards = gene_nonzero[xp.arange(gene_nonzero.shape[0]), delta_argmax]
-
-                    delta_rewards[underflowed_rows_mask] = -xp.inf
-
-                    if use_gpu:
-                        topk_reward_values, topk_reward_indices = torch.topk(
-                            torch.as_tensor(delta_rewards, device='cuda'),
-                            k=int(xp.minimum(-additional_noise_counts, delta_rewards.shape[0])),
-                            largest=True,
-                            sorted=False,
-                        )
-
-                        # TODO: check for invalid topk_reward_values as above
-
-                        #topk_reward_values = cp.asarray(topk_reward_values)
-                        topk_reward_indices = cp.asarray(topk_reward_indices)
-                    else:
-                        topk_reward_values, topk_reward_indices = torch.topk(
-                            torch.from_numpy(delta_rewards),
-                            k=int(np.minimum(-additional_noise_counts, delta_rewards.shape[0])),
-                            largest=True,
-                            sorted=False,
-                        )
-
-                        # TODO: check for invalid topk_reward_values as above
-
-                        #topk_reward_values = topk_reward_values.numpy()
-                        topk_reward_indices = topk_reward_indices.numpy()
-
-                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
-
-                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
-                        gene_noise_counts = map_argmax
-                        # print("break")
-
-                        break
-                    else:
-                        if xp.all(delta_argmax == 0):
-                            # target not achievable with all noise counts at min
-                            # print("impossible break")
-                            gene_noise_counts = map_argmax
-
-                            break
-                        else:
-                            additional_noise_counts = noise_target - xp.sum(map_argmax)
-                            # print("loop")
-
-            if xp.count_nonzero(gene_noise_counts) != 0:
-                out_data.extend(gene_noise_counts.get() if use_gpu else gene_noise_counts)
-                out_row_indices.extend(nonzero_rows.get() if use_gpu else nonzero_rows)
-                out_col_indices.extend([gene_idx.get() if use_gpu else gene_idx] * len(nonzero_rows))
-
-                # logger.debug("added col")
-
-        # TODO: verify that genes are in the correct order
-
-        if return_csr:
-            out_coo = sp.coo_matrix((out_data, (out_row_indices, out_col_indices)), shape=(n_cells, n_genes))
-
-            out_csr = sp.csr_matrix(out_coo)
-            out_csr.eliminate_zeros()
-
-            return out_csr
-        else:
-            return (
-                np.array(out_data, dtype=np.int32),
-                np.array(out_row_indices, dtype=np.int32),
-                np.array(out_col_indices, dtype=np.int32),
-            )
-
-    def estimate_noise(
-        self,
-        noise_log_prob_coo: sp.coo_matrix,
-        noise_offsets: Optional[Dict[int, int]],
-        noise_targets_per_gene: np.ndarray | None = None,
-        verbose: bool = False,
-        n_chunks: Optional[int] = None,
-        use_multiple_processes: bool = False,
-        **kwargs,
-    ) -> sp.csr_matrix:
-
-        # TODO: handle noise_offsets
-
-        t0 = time.time()
-
-        setup_gpu = True
-        use_gpu = False
-
-        if use_gpu:
-            assert setup_gpu
-            assert not use_multiple_processes #TODO: try to make this work, but it will probably be even slower
-
-        data_dtype = np.float32
-        index_dtype = np.int32 # TODO: check the effect of changing index dtypes
-
-        if setup_gpu:
-            # Do an example CuPy computation to measure CUDA context initialization time.
-            # Actually, init may happen in get_ng_indices upon calling cp.get_array_module, not sure.
-            t_cuda_init_start = time.time()
-
-            x_gpu = cp.array([1, 2, 3])
-            l2_gpu = cp.linalg.norm(x_gpu)
-            print(l2_gpu)
-
-            t_cuda_init_end = time.time()
-
-            logger.info(f"{timestamp()} cuda init time = {(t_cuda_init_end - t_cuda_init_start):.2f} sec")
-
-            data = cp.asarray(noise_log_prob_coo.data, dtype=data_dtype)
-
-            data = data - (np.floor(data.min()) - 1)
-
-            n_cells = self.index_converter.total_n_cells
-            n_genes = self.index_converter.total_n_genes
-            n_c = noise_log_prob_coo.shape[1]
-
-            n, g = self.index_converter.get_ng_indices(m_inds=cp.asarray(noise_log_prob_coo.row))
-            n = n.astype(index_dtype)
-            g = g.astype(index_dtype)
-            c = cp.asarray(noise_log_prob_coo.col, dtype=index_dtype)
-
-            order = cp.argsort(g).astype(index_dtype)  # does not support kind="mergesort", should be stable by default
-            g_sorted = g[order]
-            n_sorted = n[order]
-            c_sorted = c[order]
-            data_sorted = data[order]
-
-            unique_genes, start_idx, counts = cp.unique(g_sorted, return_index=True, return_counts=True)
-
-            start_idx = start_idx.astype(index_dtype)
-            counts = counts.astype(index_dtype)
-
-            noise_targets_per_gene = cp.asarray(noise_targets_per_gene, dtype=data_dtype)
-        else:
-            data = noise_log_prob_coo.data
-
-            data = data - (np.floor(data.min()) - 1)
-
-            n_cells = self.index_converter.total_n_cells
-            n_genes = self.index_converter.total_n_genes
-            n_c = noise_log_prob_coo.shape[1]
-
-            n, g = self.index_converter.get_ng_indices(m_inds=noise_log_prob_coo.row)
-            n = n.astype(index_dtype)
-            g = g.astype(index_dtype)
-            c = noise_log_prob_coo.col.astype(index_dtype)
-
-            # not sure if we need the mergesort for stability
-            order = np.argsort(g, kind="mergesort").astype(index_dtype)
-            g_sorted = g[order]
-            n_sorted, n_sorted_sm = self._optionally_share(n[order], use_multiple_processes)
-            c_sorted, c_sorted_sm = self._optionally_share(c[order], use_multiple_processes)
-            data_sorted, data_sorted_sm = self._optionally_share(data[order], use_multiple_processes)
-
-            unique_genes, start_idx, counts = np.unique(g_sorted, return_index=True, return_counts=True)
-
-            unique_genes, unique_genes_sm = self._optionally_share(unique_genes, use_multiple_processes)
-            start_idx, start_idx_sm = self._optionally_share(start_idx.astype(index_dtype), use_multiple_processes)
-            counts, counts_sm = self._optionally_share(counts.astype(index_dtype), use_multiple_processes)
-
-            noise_targets_per_gene, noise_targets_per_gene_sm = self._optionally_share(
-                noise_targets_per_gene.astype(data_dtype), use_multiple_processes
-            )
-
-        # Yes, it is actually faster to load and unload everything off the GPU and copy it all into shared memory.
-        if setup_gpu and not use_gpu:
-            n_sorted = n_sorted.get()
-            c_sorted = c_sorted.get()
-            data_sorted = data_sorted.get()
-
-            unique_genes = unique_genes.get()
-            start_idx = start_idx.get()
-            counts = counts.get()
-
-            noise_targets_per_gene = noise_targets_per_gene.get()
-
-            if use_multiple_processes:
-                n_sorted, n_sorted_sm = self._share(n_sorted)
-                c_sorted, c_sorted_sm = self._share(c_sorted)
-                data_sorted, data_sorted_sm = self._share(data_sorted)
-
-                unique_genes, unique_genes_sm = self._share(unique_genes)
-                start_idx, start_idx_sm = self._share(start_idx)
-                counts, counts_sm = self._share(counts)
-
-                noise_targets_per_gene, noise_targets_per_gene_sm = self._share(noise_targets_per_gene)
-
-        t_setup = time.time()
-
-        logger.info(f"{timestamp()} fast-mckp setup time = {(t_setup - t0):.2f} sec")
-
-        if use_multiple_processes:
-            #TODO: now memory usage is lower and 6 processes are faster, need to remeasure
-
-            # number of p-core threads (12) is fastest, uses ~10GB of peak memory, similar to noise target compute usage
-            # number of p-cores (6) is slightly slower, uses ~14GB of peak memory
-            # number of p-core + e-core threads (20 == mp.cpu_count()) is a couple seconds slower, uses ~17GB of peak mem
-            # this info is hard to get programmatically without obscure hacks, and there is no library support
-            # effects recent Intel and Apple CPUs
-
-            # n_processes = mp.cpu_count()
-            n_processes = 6
-
-            # TODO: preallocating return arrays didn't increase speed and doesn't work right
-            """
-            nonzero_upper_bound = 20000000
-
-            process_nonzero_upper_bound = int(nonzero_upper_bound / n_processes)
-
-            return_array, return_array_sm = self._optionally_share(
-                np.zeros(shape=(n_processes, 3, process_nonzero_upper_bound), dtype=np.int32)
-            )
-            """
-            futures = []
-            with concurrent.futures.ProcessPoolExecutor(
-                max_workers=n_processes, mp_context=mp.get_context("spawn")
-            ) as executor:
-                for i in range(n_processes):
-                    kwargs = {
-                        "unique_genes": (unique_genes.shape, unique_genes.dtype, unique_genes_sm),
-                        "start_idx": (start_idx.shape, start_idx.dtype, start_idx_sm),
-                        "counts": (counts.shape, counts.dtype, counts_sm),
-                        "n_sorted": (n_sorted.shape, n_sorted.dtype, n_sorted_sm),
-                        "c_sorted": (c_sorted.shape, c_sorted.dtype, c_sorted_sm),
-                        "data_sorted": (data_sorted.shape, data_sorted.dtype, data_sorted_sm),
-                        "noise_targets_per_gene": (
-                            noise_targets_per_gene.shape,
-                            noise_targets_per_gene.dtype,
-                            noise_targets_per_gene_sm,
-                        ),
-                        "n_cells": n_cells,
-                        "n_genes": n_genes,
-                        "n_c": n_c,
-                        "data_dtype": data_dtype,
-                        "index_dtype": index_dtype,
-                        "i": i,
-                        "n_processes": n_processes,
-                        "nnz_genes": unique_genes.size,
-                        #"return_array": (return_array.shape, return_array.dtype, return_array_sm),
-                        "return_array": None,
-                    }
-                    future = executor.submit(MultipleChoiceKnapsackFast._estimate_shared, **kwargs)
-                    futures.append(future)
-
-                done, not_done = concurrent.futures.wait(
-                    futures,
-                    return_when=concurrent.futures.ALL_COMPLETED,
-                )
-                csr_matrices = [f.result() for f in futures]
-
-            """
-            result = return_array.transpose(1, 0, 2).reshape(3, n_processes * process_nonzero_upper_bound)
-
-            out_csr = sp.csr_matrix((result[0], (result[1], result[2])), shape=(n_cells, n_genes)).copy()
-            out_csr.eliminate_zeros()
-            """
-
-            self._stop_memory_manager()
-
-            out_csr = sum(csr_matrices)
-        else:
-            mckp_results = MultipleChoiceKnapsackFast._estimate(
-                unique_genes,
-                start_idx,
-                counts,
-                n_sorted,
-                c_sorted,
-                data_sorted,
-                noise_targets_per_gene,
-                n_cells,
-                n_genes,
-                n_c,
-                data_dtype,
-                index_dtype,
-                use_gpu,
-            )
-
-            out_csr = mckp_results
-
         logger.info(f"{timestamp()} fast-mckp estimation time after prep = {(time.time() - t_setup):.2f} sec")
         logger.info(f"{timestamp()} Total fast-mckp estimation time = {(time.time() - t0):.2f} sec")
-
-        # sp.save_npz("mckp_csr_v2.npz", out_csr)
 
         return out_csr
 

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -782,6 +782,276 @@ class MultipleChoiceKnapsack(EstimationMethod):
         # The MAP already has the noise offsets, so they are not added to steps_csr.
         return map_csr + steps_csr
 
+@torch.no_grad()
+def unique_with_indices(x, sort = False, return_counts = False):
+    # TODO: scatter_reduce_ is in beta and can be nondeterministic on GPU, not sure if that matters here
+    # TODO: try torch.use_deterministic_algorithms(True)
+    # TODO: might not matter because we aren't using floats
+    # TODO: other implementations here https://github.com/pytorch/pytorch/issues/36748, but the ones I tried were slow.
+    # TODO: I have no idea how this works and I used my last free copilot credits to get this.
+    idx = torch.arange(x.numel(), device=x.device)
+
+    if return_counts:
+        u, inv, counts = torch.unique(x, sorted=sort, return_inverse=True, return_counts=True)
+    else:
+        u, inv = torch.unique(x, sorted=sort, return_inverse=True)
+        counts = None
+
+    first_idx = torch.full((u.numel(),), x.numel(), dtype=idx.dtype, device=x.device)
+    first_idx.scatter_reduce_(0, inv, idx, reduce="amin", include_self=True)
+
+    if return_counts:
+        return u, first_idx, inv, counts
+    else:
+        return u, first_idx, inv
+
+class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
+    @staticmethod
+    @torch.no_grad()
+    def densify_without_zero_rows(
+        coo: sp.coo_array | cusp.coo_matrix,
+        dtype: torch.dtype,
+        device: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # TODO: Claude made this, I'm not sure how or if it works.
+
+        coo_row = torch.from_numpy(coo.row).to(device)
+
+        nonzero_rows_ = torch.unique(coo_row)
+
+        rows_ = torch.searchsorted(nonzero_rows_, coo_row)
+
+        dense = torch.zeros((len(nonzero_rows_), coo.shape[1]), dtype=dtype)
+        dense[rows_, torch.from_numpy(coo.col).to(device)] = torch.from_numpy(coo.data).to(device)
+
+        return dense, nonzero_rows_
+
+    @staticmethod
+    @torch.no_grad()
+    def densify_without_zero_rows2(
+        data,
+        row,
+        col,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # TODO: Claude made this, I'm not sure how or if it works.
+
+        nonzero_rows_ = torch.unique(row)
+
+        rows_ = torch.searchsorted(nonzero_rows_, row)
+
+        dense = torch.zeros((nonzero_rows_.shape[0], torch.max(col) + 1), dtype=data.dtype, device=data.device)
+        dense[rows_, col] = data
+
+        return dense, nonzero_rows_
+
+    @torch.no_grad()
+    def estimate_noise(
+        self,
+        noise_log_prob_coo: sp.coo_matrix,
+        noise_offsets: Optional[Dict[int, int]],
+        noise_targets_per_gene: np.ndarray | None = None,
+        verbose: bool = False,
+        n_chunks: Optional[int] = None,
+        use_multiple_processes: bool = False,
+        **kwargs,
+    ) -> sp.csr_matrix:
+
+        # TODO: handle noise_offsets
+
+        t0 = time.time()
+
+        setup_gpu = True
+        use_gpu = False
+
+        data_dtype = torch.float32
+        index_dtype = np.int32
+
+        device = "cuda" if setup_gpu else "cpu"
+
+        n, g = self.index_converter.get_ng_indices(m_inds=noise_log_prob_coo.row)
+        n = torch.from_numpy(n).to(device)
+        g = torch.from_numpy(g).to(device)
+
+        c = torch.from_numpy(noise_log_prob_coo.col).to(device)
+
+        data = torch.from_numpy(noise_log_prob_coo.data).to(device, copy=True)
+        data = data - (torch.floor(data.min()) - 1) #TODO: consider exp
+
+        order = torch.argsort(g)
+        g_sorted = g[order]
+        n_sorted = n[order]
+        c_sorted = c[order]
+        data_sorted = data[order]
+
+        unique_genes, start_idx, _, counts = unique_with_indices(g_sorted, return_counts=True)
+
+        noise_targets_per_gene = torch.from_numpy(noise_targets_per_gene).to(device)
+
+        t_setup = time.time()
+
+        if not use_gpu:
+            device = "cpu"
+
+            n_sorted = n_sorted.to(device)
+            c_sorted = c_sorted.to(device)
+            data_sorted = data_sorted.to(device)
+
+            unique_genes = unique_genes.to(device)
+            start_idx = start_idx.to(device)
+            counts = counts.to(device)
+
+            noise_targets_per_gene = noise_targets_per_gene.to(device)
+
+        logger.info(f"{timestamp()} fast-mckp2 setup time = {(t_setup - t0):.2f} sec")
+
+        out_data = []
+        out_row_indices = []
+        out_col_indices = []
+
+        for i in range(unique_genes.shape[0]):
+            #print(f"i: {i}")
+
+            gene_idx = unique_genes[i]
+            start = start_idx[i]
+            count = counts[i]
+
+            end = start + count
+
+            gene_n = n_sorted[start:end]
+            gene_c = c_sorted[start:end]
+            gene_data = data_sorted[start:end]
+
+            gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast2.densify_without_zero_rows2(
+                gene_data, gene_n, gene_c
+            )
+
+            map_argmax = torch.argmax(gene_nonzero, dim=1)
+
+            noise_target = torch.floor(noise_targets_per_gene[gene_idx])
+
+            additional_noise_counts = noise_target - torch.sum(map_argmax, dtype=data_dtype)
+
+            step_direction = torch.sign(additional_noise_counts)
+
+            if step_direction == 0:
+                # Target == MAP
+                gene_noise_counts = map_argmax
+            elif step_direction > 0:
+                # Target > MAP
+
+                # print("step+")
+
+                max_c_idx = torch.tensor(gene_nonzero.shape[1] - 1)
+
+                while True:
+                    delta_argmax = map_argmax + 1
+
+                    overflowed_rows_mask = delta_argmax > max_c_idx
+
+                    delta_argmax = torch.minimum(delta_argmax, max_c_idx)
+
+                    delta_rewards = gene_nonzero[torch.arange(gene_nonzero.shape[0]), delta_argmax]
+
+                    delta_rewards[overflowed_rows_mask] = -torch.inf
+
+                    # TODO: maybe switch to xp.partition
+                    topk_reward_values, topk_reward_indices = torch.topk(
+                        delta_rewards,
+                        k=int(torch.minimum(additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
+                        largest=True,
+                        sorted=False,
+                    )
+
+                    if torch.any((topk_reward_values == 0.0) | (topk_reward_values == -torch.inf)):
+                        # print("not enough extra possible counts")
+                        topk_reward_indices = topk_reward_indices[
+                            ~((topk_reward_values == 0.0) | (topk_reward_values == -torch.inf))
+                        ]
+
+                        map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                        gene_noise_counts = map_argmax
+
+                        break
+
+                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
+                        gene_noise_counts = map_argmax
+                        # print("break")
+
+                        break
+                    else:
+                        if torch.all(delta_argmax == max_c_idx):
+                            # target not achievable with all noise counts maxed
+                            # print("impossible break")
+                            gene_noise_counts = map_argmax
+
+                            break
+                        else:
+                            additional_noise_counts = noise_target - torch.sum(map_argmax)
+                            # print("loop")
+
+            elif step_direction < 0:
+                # Target < MAP
+                # print("step-")
+
+                while True:
+                    delta_argmax = map_argmax - 1
+
+                    underflowed_rows_mask = delta_argmax < 0
+
+                    delta_argmax = torch.maximum(delta_argmax, torch.tensor(0))
+
+                    delta_rewards = gene_nonzero[torch.arange(gene_nonzero.shape[0]), delta_argmax]
+
+                    delta_rewards[underflowed_rows_mask] = -torch.inf
+
+                    topk_reward_values, topk_reward_indices = torch.topk(
+                        delta_rewards,
+                        k=int(torch.minimum(-additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
+                        largest=True,
+                        sorted=False,
+                    )
+
+                    # TODO: check for invalid topk_reward_values as above
+
+                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
+                        gene_noise_counts = map_argmax
+                        # print("break")
+
+                        break
+                    else:
+                        if torch.all(delta_argmax == 0):
+                            # target not achievable with all noise counts at min
+                            # print("impossible break")
+                            gene_noise_counts = map_argmax
+
+                            break
+                        else:
+                            additional_noise_counts = noise_target - torch.sum(map_argmax)
+                            # print("loop")
+
+            if torch.count_nonzero(gene_noise_counts) != 0:
+                out_data.extend(gene_noise_counts.numpy(force=True))
+                out_row_indices.extend(nonzero_rows.numpy(force=True))
+                out_col_indices.extend(np.ones_like(nonzero_rows.numpy(force=True)) * gene_idx.numpy(force=True))
+
+                # logger.debug("added col")
+
+        out_coo = sp.coo_matrix((np.array(out_data), (np.array(out_row_indices), np.array(out_col_indices))),
+                                shape=(self.index_converter.total_n_cells, self.index_converter.total_n_genes))
+
+        out_csr = sp.csr_matrix(out_coo)
+        out_csr.eliminate_zeros()
+
+        logger.info(f"{timestamp()} fast-mckp2 estimation time after prep = {(time.time() - t_setup):.2f} sec")
+        logger.info(f"{timestamp()} Total fast-mckp2 estimation time = {(time.time() - t0):.2f} sec")
+
+        return out_csr
+
 class MultipleChoiceKnapsackFast(SharedEstimationMethod):
     @staticmethod
     def densify_without_zero_rows(coo: sp.coo_array | cusp.coo_matrix) -> tuple[np.ndarray | cp.ndarray, np.ndarray | cp.ndarray]:

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -4,9 +4,6 @@ import concurrent.futures
 import logging
 import multiprocessing as mp
 import sys
-from multiprocessing import shared_memory
-from multiprocessing.managers import SharedMemoryManager
-import torch.multiprocessing as torchmp
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -19,6 +16,7 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 import torch
+import torch.multiprocessing as torchmp
 from torch.distributions.categorical import Categorical
 
 from cellbender.remove_background.sparse_utils import log_prob_sparse_to_dense
@@ -88,6 +86,7 @@ class EstimationMethod(ABC):
         #                     shape=self.index_converter.matrix_shape, dtype=dtype)
         # coo.sum_duplicates()
         # return coo.tocsr()
+
 
 class SingleSample(EstimationMethod):
     """A single sample from the noise count posterior"""

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing as mp
 from multiprocessing import shared_memory
 from multiprocessing.managers import SharedMemoryManager
+import torch.multiprocessing as torchmp
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -805,6 +806,189 @@ def unique_with_indices(x, sort = False, return_counts = False):
     else:
         return u, first_idx, inv
 
+def _estimate_fast_mckp2(
+    process_index,
+    gene_chunks,
+    use_multiple_processes,
+    out_stack_queue,
+    unique_genes,
+    start_idx, 
+    counts,
+    n_sorted,
+    c_sorted,
+    data_sorted,
+    noise_targets_per_gene,
+    index_converter,
+    data_dtype,
+    n_threads
+):
+    t0 = time.time()
+
+    out_data = []
+    out_row_indices = []
+    out_col_indices = []
+
+    torch.set_num_threads(n_threads)
+
+    for i in np.array(gene_chunks[process_index]):
+        # print(f"i: {i}")
+
+        gene_idx = unique_genes[i]
+        start = start_idx[i]
+        count = counts[i]
+
+        end = start + count
+
+        gene_n = n_sorted[start:end]
+        gene_c = c_sorted[start:end]
+        gene_data = data_sorted[start:end]
+
+        gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast2.densify_without_zero_rows2(gene_data, gene_n, gene_c)
+
+        map_argmax = torch.argmax(gene_nonzero, dim=1)
+
+        noise_target = torch.floor(noise_targets_per_gene[gene_idx])
+
+        additional_noise_counts = noise_target - torch.sum(map_argmax, dtype=data_dtype)
+
+        step_direction = torch.sign(additional_noise_counts)
+
+        if step_direction == 0:
+            # Target == MAP
+            gene_noise_counts = map_argmax
+        elif step_direction > 0:
+            # Target > MAP
+
+            # print("step+")
+
+            max_c_idx = torch.tensor(gene_nonzero.shape[1] - 1)
+
+            while True:
+                delta_argmax = map_argmax + 1
+
+                overflowed_rows_mask = delta_argmax > max_c_idx
+
+                delta_argmax = torch.minimum(delta_argmax, max_c_idx)
+
+                delta_rewards = gene_nonzero[torch.arange(gene_nonzero.shape[0]), delta_argmax]
+
+                delta_rewards[overflowed_rows_mask] = -torch.inf
+
+                # TODO: maybe switch to xp.partition
+                topk_reward_values, topk_reward_indices = torch.topk(
+                    delta_rewards,
+                    k=int(torch.minimum(additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
+                    largest=True,
+                    sorted=False,
+                )
+
+                if torch.any((topk_reward_values == 0.0) | (topk_reward_values == -torch.inf)):
+                    # print("not enough extra possible counts")
+                    topk_reward_indices = topk_reward_indices[
+                        ~((topk_reward_values == 0.0) | (topk_reward_values == -torch.inf))
+                    ]
+
+                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                    gene_noise_counts = map_argmax
+
+                    break
+
+                map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                if map_argmax.sum() == noise_target:  # probly inconsistent rounding
+                    gene_noise_counts = map_argmax
+                    # print("break")
+
+                    break
+                else:
+                    if torch.all(delta_argmax == max_c_idx):
+                        # target not achievable with all noise counts maxed
+                        # print("impossible break")
+                        gene_noise_counts = map_argmax
+
+                        break
+                    else:
+                        additional_noise_counts = noise_target - torch.sum(map_argmax)
+                        # print("loop")
+
+        elif step_direction < 0:
+            # Target < MAP
+            # print("step-")
+
+            while True:
+                delta_argmax = map_argmax - 1
+
+                underflowed_rows_mask = delta_argmax < 0
+
+                delta_argmax = torch.maximum(delta_argmax, torch.tensor(0))
+
+                delta_rewards = gene_nonzero[torch.arange(gene_nonzero.shape[0]), delta_argmax]
+
+                delta_rewards[underflowed_rows_mask] = -torch.inf
+
+                topk_reward_values, topk_reward_indices = torch.topk(
+                    delta_rewards,
+                    k=int(torch.minimum(-additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
+                    largest=True,
+                    sorted=False,
+                )
+
+                # TODO: check for invalid topk_reward_values as above
+
+                map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
+
+                if map_argmax.sum() == noise_target:  # probly inconsistent rounding
+                    gene_noise_counts = map_argmax
+                    # print("break")
+
+                    break
+                else:
+                    if torch.all(delta_argmax == 0):
+                        # target not achievable with all noise counts at min
+                        # print("impossible break")
+                        gene_noise_counts = map_argmax
+
+                        break
+                    else:
+                        additional_noise_counts = noise_target - torch.sum(map_argmax)
+                        # print("loop")
+
+        if torch.count_nonzero(gene_noise_counts) != 0:
+            out_data.extend(gene_noise_counts.numpy(force=True))
+            out_row_indices.extend(nonzero_rows.numpy(force=True))
+            out_col_indices.extend(np.ones_like(nonzero_rows.numpy(force=True)) * gene_idx.numpy(force=True))
+
+            # logger.debug("added col")
+
+    if use_multiple_processes:
+        out_coo = sp.coo_matrix(
+            (np.array(out_data), (np.array(out_row_indices), np.array(out_col_indices))),
+            shape=(index_converter.total_n_cells, index_converter.total_n_genes),
+        )
+        out_coo.eliminate_zeros()
+        #TODO: zero-mask data and subset, no conversion to coo needed (hopefully fast)
+
+        out_stack_queue.put(
+            torch.stack((torch.tensor(out_coo.data), torch.tensor(out_coo.row), torch.tensor(out_coo.col)))
+        )
+
+
+
+        out_csr = None
+    else:
+        out_coo = sp.coo_matrix(
+            (np.array(out_data), (np.array(out_row_indices), np.array(out_col_indices))),
+            shape=(index_converter.total_n_cells, index_converter.total_n_genes),
+        )
+
+        out_csr = sp.csr_matrix(out_coo)
+        out_csr.eliminate_zeros()
+
+    print(f"{timestamp()} fast-mckp2 process {process_index} time = {(time.time() - t0):.2f} sec")
+
+    return out_csr
+
 class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
     @staticmethod
     @torch.no_grad()
@@ -863,10 +1047,48 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
         setup_gpu = True
         use_gpu = False
 
+        n_processes = 6
+        n_threads_per_process_single = 6
+        n_threads_per_process_multiple = 1
+
         data_dtype = torch.float32
         index_dtype = np.int32
 
         device = "cuda" if setup_gpu else "cpu"
+
+        # restored later
+        original_torch_num_thread = torch.get_num_threads()
+
+        if not use_multiple_processes:
+            torch.set_num_threads(n_threads_per_process_single)
+
+        # TODO: test RAM and VRAM usage
+
+        # p-core/e-core counts are hard to get programmatically without obscure hacks.
+        # This effects recent Intel and Apple CPUs, and there is no library support.
+        # Looks like number of physical p-cores is best.
+
+        # wtih setup_gpu = False, use_gpu = False, use_multiple_processes = False
+        # 1
+        #   setup:  4.8
+        #   run:    11.69
+        #   total:  16.49
+        # 6 (p-core count)
+        #   setup:  3.52
+        #   run:    10.03
+        #   total:  13.55
+        # 12 (p-core thread count)
+        #   setup:  3.58
+        #   run:    11.81
+        #   total:  15.39
+        # 14 (default)
+        #   setup:  3.61
+        #   run:    11.75
+        #   total:  15.36
+        # 20 (p-core + e-core thread count)
+        #   setup:  6.81
+        #   run:    22.53
+        #   total:  29.34
 
         n, g = self.index_converter.get_ng_indices(m_inds=noise_log_prob_coo.row)
         n = torch.from_numpy(n).to(device)
@@ -875,7 +1097,10 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
         c = torch.from_numpy(noise_log_prob_coo.col).to(device)
 
         data = torch.from_numpy(noise_log_prob_coo.data).to(device, copy=True)
-        data = data - (torch.floor(data.min()) - 1) #TODO: consider exp
+
+        # Exponentiating works, but reduces floating-point precision.
+        # TODO: I forget, why does this not work for negative data now that I'm not using BISSA?
+        data = data - (torch.floor(data.min()) - 1)
 
         order = torch.argsort(g)
         g_sorted = g[order]
@@ -886,8 +1111,6 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
         unique_genes, start_idx, _, counts = unique_with_indices(g_sorted, return_counts=True)
 
         noise_targets_per_gene = torch.from_numpy(noise_targets_per_gene).to(device)
-
-        t_setup = time.time()
 
         if not use_gpu:
             device = "cpu"
@@ -902,150 +1125,80 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
 
             noise_targets_per_gene = noise_targets_per_gene.to(device)
 
+        t_setup = time.time()
+
         logger.info(f"{timestamp()} fast-mckp2 setup time = {(t_setup - t0):.2f} sec")
 
-        out_data = []
-        out_row_indices = []
-        out_col_indices = []
+        if use_multiple_processes:
+            gene_chunks = torch.arange(unique_genes.shape[0]).tensor_split(n_processes)
 
-        for i in range(unique_genes.shape[0]):
-            #print(f"i: {i}")
+            out_stack_queue = torchmp.Queue()
 
-            gene_idx = unique_genes[i]
-            start = start_idx[i]
-            count = counts[i]
-
-            end = start + count
-
-            gene_n = n_sorted[start:end]
-            gene_c = c_sorted[start:end]
-            gene_data = data_sorted[start:end]
-
-            gene_nonzero, nonzero_rows = MultipleChoiceKnapsackFast2.densify_without_zero_rows2(
-                gene_data, gene_n, gene_c
+            process_context = torchmp.spawn(
+                _estimate_fast_mckp2,
+                args=(
+                    gene_chunks,
+                    use_multiple_processes,
+                    out_stack_queue,
+                    unique_genes,
+                    start_idx,
+                    counts,
+                    n_sorted,
+                    c_sorted,
+                    data_sorted,
+                    noise_targets_per_gene,
+                    self.index_converter,
+                    data_dtype,
+                    n_threads_per_process_multiple,
+                ),
+                nprocs=n_processes,
+                join=False,
+                daemon=True,
+                #TODO: start_method = "fork" on linux (might not work with CUDA (might need forkserver))
             )
 
-            map_argmax = torch.argmax(gene_nonzero, dim=1)
+            t_collect = time.time()
 
-            noise_target = torch.floor(noise_targets_per_gene[gene_idx])
+            out_csr_list = []
 
-            additional_noise_counts = noise_target - torch.sum(map_argmax, dtype=data_dtype)
+            for i in range(n_processes):
+                out_stack = out_stack_queue.get()
 
-            step_direction = torch.sign(additional_noise_counts)
+                out_csr_list.append(
+                    sp.csr_matrix((np.array(out_stack[0]), (np.array(out_stack[1]), np.array(out_stack[2]))),
+                                        shape=(self.index_converter.total_n_cells, self.index_converter.total_n_genes),)
+                )
 
-            if step_direction == 0:
-                # Target == MAP
-                gene_noise_counts = map_argmax
-            elif step_direction > 0:
-                # Target > MAP
+                del out_stack
 
-                # print("step+")
+            process_context.join()
 
-                max_c_idx = torch.tensor(gene_nonzero.shape[1] - 1)
+            #TODO: Warning on process close when using CUDA. This might be a pain to fix, see
+            # https://docs.pytorch.org/docs/2.12/multiprocessing.html#multiprocessing-cuda-sharing-details
 
-                while True:
-                    delta_argmax = map_argmax + 1
+            out_csr = sum(out_csr_list)
 
-                    overflowed_rows_mask = delta_argmax > max_c_idx
+            logger.info(f"{timestamp()} fast-mckp2 collection time = {(time.time() - t_collect):.2f} sec")
 
-                    delta_argmax = torch.minimum(delta_argmax, max_c_idx)
+        else:
+            out_csr = _estimate_fast_mckp2(
+                0,
+                torch.unsqueeze(torch.arange(unique_genes.shape[0]), dim=0),
+                use_multiple_processes,
+                None,
+                unique_genes,
+                start_idx,
+                counts,
+                n_sorted,
+                c_sorted,
+                data_sorted,
+                noise_targets_per_gene,
+                self.index_converter,
+                data_dtype,
+                n_threads_per_process_single,
+            )
 
-                    delta_rewards = gene_nonzero[torch.arange(gene_nonzero.shape[0]), delta_argmax]
-
-                    delta_rewards[overflowed_rows_mask] = -torch.inf
-
-                    # TODO: maybe switch to xp.partition
-                    topk_reward_values, topk_reward_indices = torch.topk(
-                        delta_rewards,
-                        k=int(torch.minimum(additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
-                        largest=True,
-                        sorted=False,
-                    )
-
-                    if torch.any((topk_reward_values == 0.0) | (topk_reward_values == -torch.inf)):
-                        # print("not enough extra possible counts")
-                        topk_reward_indices = topk_reward_indices[
-                            ~((topk_reward_values == 0.0) | (topk_reward_values == -torch.inf))
-                        ]
-
-                        map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
-
-                        gene_noise_counts = map_argmax
-
-                        break
-
-                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
-
-                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
-                        gene_noise_counts = map_argmax
-                        # print("break")
-
-                        break
-                    else:
-                        if torch.all(delta_argmax == max_c_idx):
-                            # target not achievable with all noise counts maxed
-                            # print("impossible break")
-                            gene_noise_counts = map_argmax
-
-                            break
-                        else:
-                            additional_noise_counts = noise_target - torch.sum(map_argmax)
-                            # print("loop")
-
-            elif step_direction < 0:
-                # Target < MAP
-                # print("step-")
-
-                while True:
-                    delta_argmax = map_argmax - 1
-
-                    underflowed_rows_mask = delta_argmax < 0
-
-                    delta_argmax = torch.maximum(delta_argmax, torch.tensor(0))
-
-                    delta_rewards = gene_nonzero[torch.arange(gene_nonzero.shape[0]), delta_argmax]
-
-                    delta_rewards[underflowed_rows_mask] = -torch.inf
-
-                    topk_reward_values, topk_reward_indices = torch.topk(
-                        delta_rewards,
-                        k=int(torch.minimum(-additional_noise_counts, torch.tensor(delta_rewards.shape[0]))),
-                        largest=True,
-                        sorted=False,
-                    )
-
-                    # TODO: check for invalid topk_reward_values as above
-
-                    map_argmax[topk_reward_indices] = delta_argmax[topk_reward_indices]
-
-                    if map_argmax.sum() == noise_target:  # probly inconsistent rounding
-                        gene_noise_counts = map_argmax
-                        # print("break")
-
-                        break
-                    else:
-                        if torch.all(delta_argmax == 0):
-                            # target not achievable with all noise counts at min
-                            # print("impossible break")
-                            gene_noise_counts = map_argmax
-
-                            break
-                        else:
-                            additional_noise_counts = noise_target - torch.sum(map_argmax)
-                            # print("loop")
-
-            if torch.count_nonzero(gene_noise_counts) != 0:
-                out_data.extend(gene_noise_counts.numpy(force=True))
-                out_row_indices.extend(nonzero_rows.numpy(force=True))
-                out_col_indices.extend(np.ones_like(nonzero_rows.numpy(force=True)) * gene_idx.numpy(force=True))
-
-                # logger.debug("added col")
-
-        out_coo = sp.coo_matrix((np.array(out_data), (np.array(out_row_indices), np.array(out_col_indices))),
-                                shape=(self.index_converter.total_n_cells, self.index_converter.total_n_genes))
-
-        out_csr = sp.csr_matrix(out_coo)
-        out_csr.eliminate_zeros()
+        torch.set_num_threads(original_torch_num_thread)
 
         logger.info(f"{timestamp()} fast-mckp2 estimation time after prep = {(time.time() - t_setup):.2f} sec")
         logger.info(f"{timestamp()} Total fast-mckp2 estimation time = {(time.time() - t0):.2f} sec")

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -3,6 +3,7 @@
 import concurrent.futures
 import logging
 import multiprocessing as mp
+import sys
 from multiprocessing import shared_memory
 from multiprocessing.managers import SharedMemoryManager
 import torch.multiprocessing as torchmp
@@ -806,6 +807,7 @@ def unique_with_indices(x, sort = False, return_counts = False):
     else:
         return u, first_idx, inv
 
+@torch.no_grad()
 def _estimate_fast_mckp2(
     process_index,
     gene_chunks,
@@ -818,19 +820,23 @@ def _estimate_fast_mckp2(
     c_sorted,
     data_sorted,
     noise_targets_per_gene,
-    index_converter,
+    total_n_cells,
+    total_n_genes,
     data_dtype,
-    n_threads
+    n_threads,
+    t_start,
 ):
-    t0 = time.time()
+    print(f"{timestamp()} fast-mckp2 process {process_index} time to start = {(time.time() - t_start):.2f} sec")
 
-    out_data = []
-    out_row_indices = []
-    out_col_indices = []
+    t0 = time.time()
 
     torch.set_num_threads(n_threads)
 
-    for i in np.array(gene_chunks[process_index]):
+    out_data = torch.zeros(0, dtype=torch.int64, device=data_sorted.device)
+    out_row_indices = torch.zeros(0, dtype=torch.int64, device=data_sorted.device)
+    out_col_indices = torch.zeros(0, dtype=torch.int64, device=data_sorted.device)
+
+    for i in gene_chunks[process_index]:
         # print(f"i: {i}")
 
         gene_idx = unique_genes[i]
@@ -954,36 +960,29 @@ def _estimate_fast_mckp2(
                         additional_noise_counts = noise_target - torch.sum(map_argmax)
                         # print("loop")
 
-        if torch.count_nonzero(gene_noise_counts) != 0:
-            out_data.extend(gene_noise_counts.numpy(force=True))
-            out_row_indices.extend(nonzero_rows.numpy(force=True))
-            out_col_indices.extend(np.ones_like(nonzero_rows.numpy(force=True)) * gene_idx.numpy(force=True))
+        nonzero_mask = gene_noise_counts != 0
+
+        if torch.sum(nonzero_mask) != 0:
+            nz_noise_counts = gene_noise_counts[nonzero_mask]
+
+            out_data = torch.cat((out_data, nz_noise_counts), dim=0)
+            out_row_indices = torch.cat((out_row_indices, nonzero_rows[nonzero_mask]), dim=0)
+            out_col_indices = torch.cat((out_col_indices, torch.ones_like(nz_noise_counts) * gene_idx), dim=0)
 
             # logger.debug("added col")
 
     if use_multiple_processes:
-        out_coo = sp.coo_matrix(
-            (np.array(out_data), (np.array(out_row_indices), np.array(out_col_indices))),
-            shape=(index_converter.total_n_cells, index_converter.total_n_genes),
-        )
-        out_coo.eliminate_zeros()
-        #TODO: zero-mask data and subset, no conversion to coo needed (hopefully fast)
-
         out_stack_queue.put(
-            torch.stack((torch.tensor(out_coo.data), torch.tensor(out_coo.row), torch.tensor(out_coo.col)))
+            torch.stack((out_data, out_row_indices, out_col_indices))
         )
-
-
 
         out_csr = None
     else:
-        out_coo = sp.coo_matrix(
-            (np.array(out_data), (np.array(out_row_indices), np.array(out_col_indices))),
-            shape=(index_converter.total_n_cells, index_converter.total_n_genes),
+        out_csr = sp.csr_matrix(
+            (out_data.numpy(force=True),
+             (out_row_indices.numpy(force=True), out_col_indices.numpy(force=True))),
+            shape=(total_n_cells, total_n_genes),
         )
-
-        out_csr = sp.csr_matrix(out_coo)
-        out_csr.eliminate_zeros()
 
     print(f"{timestamp()} fast-mckp2 process {process_index} time = {(time.time() - t0):.2f} sec")
 
@@ -1112,29 +1111,40 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
 
         noise_targets_per_gene = torch.from_numpy(noise_targets_per_gene).to(device)
 
-        if not use_gpu:
-            device = "cpu"
+        device = "cuda" if use_gpu else "cpu"
 
-            n_sorted = n_sorted.to(device)
-            c_sorted = c_sorted.to(device)
-            data_sorted = data_sorted.to(device)
+        n_sorted = n_sorted.to(device)
+        c_sorted = c_sorted.to(device)
+        data_sorted = data_sorted.to(device)
 
-            unique_genes = unique_genes.to(device)
-            start_idx = start_idx.to(device)
-            counts = counts.to(device)
+        unique_genes = unique_genes.to(device)
+        start_idx = start_idx.to(device)
+        counts = counts.to(device)
 
-            noise_targets_per_gene = noise_targets_per_gene.to(device)
+        noise_targets_per_gene = noise_targets_per_gene.to(device)
 
         t_setup = time.time()
 
         logger.info(f"{timestamp()} fast-mckp2 setup time = {(t_setup - t0):.2f} sec")
 
         if use_multiple_processes:
-            gene_chunks = torch.arange(unique_genes.shape[0]).tensor_split(n_processes)
+            gene_chunks = torch.arange(unique_genes.shape[0], device=device).tensor_split(n_processes)
 
             out_stack_queue = torchmp.Queue()
 
-            process_context = torchmp.spawn(
+            # Sharing CUDA tensors requires spawn or forkserver.
+            # Only spawn works on Windows and Mac, but is slow.
+            # see https://docs.python.org/3/library/sys.html#sys.platform
+            # see https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+            # see https://docs.pytorch.org/docs/2.12/multiprocessing.html#sharing-cuda-tensors
+            # TODO: Check compatibility for other platforms.
+            start_method = "spawn"
+            if sys.platform == "linux":
+                start_method = "forkserver"
+
+            t_start = time.time()
+
+            process_context = torchmp.start_processes(
                 _estimate_fast_mckp2,
                 args=(
                     gene_chunks,
@@ -1147,14 +1157,17 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
                     c_sorted,
                     data_sorted,
                     noise_targets_per_gene,
-                    self.index_converter,
+                    self.index_converter.total_n_cells,
+                    self.index_converter.total_n_genes,
                     data_dtype,
                     n_threads_per_process_multiple,
+                    t_start,
                 ),
                 nprocs=n_processes,
                 join=False,
                 daemon=True,
-                #TODO: start_method = "fork" on linux (might not work with CUDA (might need forkserver))
+                start_method=start_method
+                # TODO: start_method = "fork" on linux (might not work with CUDA (might need forkserver))
             )
 
             t_collect = time.time()
@@ -1162,10 +1175,10 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
             out_csr_list = []
 
             for i in range(n_processes):
-                out_stack = out_stack_queue.get()
+                out_stack = out_stack_queue.get().numpy(force=True)
 
                 out_csr_list.append(
-                    sp.csr_matrix((np.array(out_stack[0]), (np.array(out_stack[1]), np.array(out_stack[2]))),
+                    sp.csr_matrix((out_stack[0], (out_stack[1], out_stack[2])),
                                         shape=(self.index_converter.total_n_cells, self.index_converter.total_n_genes),)
                 )
 
@@ -1181,6 +1194,8 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
             logger.info(f"{timestamp()} fast-mckp2 collection time = {(time.time() - t_collect):.2f} sec")
 
         else:
+            t_start = time.time()
+
             out_csr = _estimate_fast_mckp2(
                 0,
                 torch.unsqueeze(torch.arange(unique_genes.shape[0]), dim=0),
@@ -1193,9 +1208,11 @@ class MultipleChoiceKnapsackFast2(SharedEstimationMethod):
                 c_sorted,
                 data_sorted,
                 noise_targets_per_gene,
-                self.index_converter,
+                self.index_converter.total_n_cells,
+                self.index_converter.total_n_genes,
                 data_dtype,
                 n_threads_per_process_single,
+                t_start,
             )
 
         torch.set_num_threads(original_torch_num_thread)

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from cellbender.remove_background.model import RemoveBackgroundPyroModel
 
 import numpy as np
-import cupy as cp
 import pyro
 import pyro.distributions as dist
 import scipy.sparse as sp
@@ -1577,8 +1576,8 @@ class IndexConverter:
 
     def get_ng_indices(
         self,
-        m_inds: np.ndarray | cp.ndarray,
-    ) -> Tuple[np.ndarray | cp.ndarray, np.ndarray | cp.ndarray]:
+        m_inds: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """Given a list of 'm' index values, return two arrays: cell index values
         and gene index values, suitable for a sparse matrix.
         """
@@ -1588,9 +1587,7 @@ class IndexConverter:
                 f"{m_inds[(m_inds < 0) | (m_inds >= self.total_n_cells * self.total_n_genes)]}"
             )
 
-        xp = cp.get_array_module(m_inds)
-
-        return xp.divmod(m_inds, self.total_n_genes)
+        return np.divmod(m_inds, self.total_n_genes)
 
 
 def compute_mean_target_removal_as_function(

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from cellbender.remove_background.model import RemoveBackgroundPyroModel
 
 import numpy as np
+import cupy as cp
 import pyro
 import pyro.distributions as dist
 import scipy.sparse as sp
@@ -1574,7 +1575,10 @@ class IndexConverter:
         else:
             raise ValueError("IndexConverter.get_m_indices received cell_inds of unkown object type")
 
-    def get_ng_indices(self, m_inds: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def get_ng_indices(
+        self,
+        m_inds: np.ndarray | cp.ndarray,
+    ) -> Tuple[np.ndarray | cp.ndarray, np.ndarray | cp.ndarray]:
         """Given a list of 'm' index values, return two arrays: cell index values
         and gene index values, suitable for a sparse matrix.
         """
@@ -1583,7 +1587,10 @@ class IndexConverter:
                 f"Requested m_inds out of range: "
                 f"{m_inds[(m_inds < 0) | (m_inds >= self.total_n_cells * self.total_n_genes)]}"
             )
-        return np.divmod(m_inds, self.total_n_genes)
+
+        xp = cp.get_array_module(m_inds)
+
+        return xp.divmod(m_inds, self.total_n_genes)
 
 
 def compute_mean_target_removal_as_function(

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -1589,7 +1589,7 @@ class IndexConverter:
 def compute_mean_target_removal_as_function(
     noise_count_posterior_coo: sp.coo_matrix,
     noise_offsets: Optional[Dict[int, int]],
-    index_converter: IndexConverter,
+    target_estimator: EstimationMethod,
     raw_count_csr_for_cells: sp.csr_matrix,
     n_cells: int,
     device: str,
@@ -1621,8 +1621,7 @@ def compute_mean_target_removal_as_function(
     # TODO: s1.h5 with FPR 0.99 only removes 50% of signal
 
     # Compute the expected noise using mean summarization.
-    estimator = Mean(index_converter=index_converter)
-    mean_noise_csr = estimator.estimate_noise(
+    mean_noise_csr = target_estimator.estimate_noise(
         noise_log_prob_coo=noise_count_posterior_coo,
         noise_offsets=noise_offsets,
         device=device,

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -1574,10 +1574,7 @@ class IndexConverter:
         else:
             raise ValueError("IndexConverter.get_m_indices received cell_inds of unkown object type")
 
-    def get_ng_indices(
-        self,
-        m_inds: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    def get_ng_indices(self, m_inds: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """Given a list of 'm' index values, return two arrays: cell index values
         and gene index values, suitable for a sparse matrix.
         """
@@ -1586,7 +1583,6 @@ class IndexConverter:
                 f"Requested m_inds out of range: "
                 f"{m_inds[(m_inds < 0) | (m_inds >= self.total_n_cells * self.total_n_genes)]}"
             )
-
         return np.divmod(m_inds, self.total_n_genes)
 
 

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -1605,7 +1605,8 @@ def compute_mean_target_removal_as_function(
     Args:
         noise_count_posterior_coo: Noise count posterior log prob COO
         noise_offsets: Offset noise counts per 'm' index
-        index_converter: IndexConverter object from 'm' to (n, g) and back
+        target_estimator: EstimationMethod object which calculates means
+            i.e. either Mean or MeanFast
         raw_count_csr_for_cells: The input count matrix for only the cells
             included in the posterior
         n_cells: Number of cells included in the posterior, same number as in

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -26,7 +26,8 @@ from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.data.dataprep import prep_sparse_data_for_training as prep_data_for_training
 from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset, get_dataset_obj
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
-from cellbender.remove_background.estimation import MAP, Mean, MultipleChoiceKnapsack, SingleSample, ThresholdCDF
+from cellbender.remove_background.estimation import MAP, Mean, MultipleChoiceKnapsack, MultipleChoiceKnapsackFast, \
+    SingleSample, ThresholdCDF
 from cellbender.remove_background.exceptions import ElboException
 from cellbender.remove_background.model import RemoveBackgroundPyroModel
 from cellbender.remove_background.posterior import (
@@ -258,8 +259,11 @@ def compute_output_denoised_counts_reports_metrics(
         estimator = SingleSample
     elif args.estimator == "cdf":
         estimator = ThresholdCDF
-    elif args.estimator == "mckp":
-        estimator = MultipleChoiceKnapsack
+    elif args.estimator == "mckp" or args.estimator == "fast-mckp":
+        if args.estimator == "mckp":
+            estimator = MultipleChoiceKnapsack
+        elif args.estimator == "fast-mckp":
+            estimator = MultipleChoiceKnapsackFast
 
         # Prep specific for MCKP: target estimation.
         logger.info("Computing target noise counts per gene for MCKP estimator")
@@ -281,7 +285,7 @@ def compute_output_denoised_counts_reports_metrics(
         def noise_target_fun(x):
             return noise_target_fun_per_cell(x) * len(cell_inds)
     else:
-        raise ValueError('Input --estimator must be one of ["map", "mean", "sample", "cdf", "mckp"]')
+        raise ValueError('Input --estimator must be one of ["map", "mean", "sample", "cdf", "mckp", "fast-mckp"]')
 
     # Save denoised count matrix outputs (for each FPR if applicable).
     success = True

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -262,8 +262,17 @@ def compute_output_denoised_counts_reports_metrics(
     elif args.estimator == "mckp" or args.estimator == "fast-mckp":
         if args.estimator == "mckp":
             estimator = MultipleChoiceKnapsack
-        elif args.estimator == "fast-mckp":
+
+            use_cuda_compute_mean_device = "gpu"
+        else: #args.estimator == "fast-mckp":
             estimator = MultipleChoiceKnapsackFast
+
+            # TODO: check to see if fast-MCKP is in GPU mode
+
+            # Disables GPU calculations here to save VRAM for fast-MCKP.
+            # Might instead be able to manually free memory after noise target computation, but
+            # there wasn't a noticeable performance difference.
+            use_cuda_compute_mean_device = "cpu"
 
         # Prep specific for MCKP: target estimation.
         logger.info("Computing target noise counts per gene for MCKP estimator")
@@ -278,7 +287,7 @@ def compute_output_denoised_counts_reports_metrics(
             index_converter=posterior.index_converter,
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
-            device="cuda" if args.use_cuda else "cpu",  # TODO check this
+            device=use_cuda_compute_mean_device if args.use_cuda else "cpu",  # TODO check this
             per_gene=True,
         )
 

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import sys
+import time
 import traceback
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple, Union, cast
@@ -249,6 +250,8 @@ def compute_output_denoised_counts_reports_metrics(
     # Choose output count matrix estimation method.
     from cellbender.remove_background.estimation import EstimationMethod
 
+    t0 = time.time()
+
     estimator: type[EstimationMethod]
     noise_target_fun = None
     if args.estimator == "map":
@@ -327,6 +330,8 @@ def compute_output_denoised_counts_reports_metrics(
             device="cuda" if args.use_cuda else "cpu",
             use_multiple_processes=args.use_multiprocessing_estimation,
         )
+
+        logger.info(f"Total target estimation + denoise time = {(time.time() - t0):.2f} sec")
 
         # Restore eliminated features in cells.
         logger.debug("Restoring eliminated features in cells")

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -28,7 +28,7 @@ from cellbender.remove_background.data.dataprep import prep_sparse_data_for_trai
 from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset, get_dataset_obj
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
 from cellbender.remove_background.estimation import MAP, Mean, MultipleChoiceKnapsack, MultipleChoiceKnapsackFast, \
-    MultipleChoiceKnapsackFast2, SingleSample, ThresholdCDF
+    SingleSample, ThresholdCDF
 from cellbender.remove_background.exceptions import ElboException
 from cellbender.remove_background.model import RemoveBackgroundPyroModel
 from cellbender.remove_background.posterior import (
@@ -262,13 +262,11 @@ def compute_output_denoised_counts_reports_metrics(
         estimator = SingleSample
     elif args.estimator == "cdf":
         estimator = ThresholdCDF
-    elif args.estimator == "mckp" or args.estimator == "fast-mckp" or args.estimator == "fast-mckp2":
+    elif args.estimator == "mckp" or args.estimator == "fast-mckp":
         if args.estimator == "mckp":
             estimator = MultipleChoiceKnapsack
-        elif args.estimator == "fast-mckp":
+        else: #args.estimator == "fast-mckp":
             estimator = MultipleChoiceKnapsackFast
-        else:
-            estimator = MultipleChoiceKnapsackFast2
 
         # Prep specific for MCKP: target estimation.
         logger.info("Computing target noise counts per gene for MCKP estimator")
@@ -290,7 +288,7 @@ def compute_output_denoised_counts_reports_metrics(
         def noise_target_fun(x):
             return noise_target_fun_per_cell(x) * len(cell_inds)
     else:
-        raise ValueError('Input --estimator must be one of ["map", "mean", "sample", "cdf", "mckp", "fast-mckp", "fast-mckp2"]')
+        raise ValueError('Input --estimator must be one of ["map", "mean", "sample", "cdf", "mckp", "fast-mckp"]')
 
     # Save denoised count matrix outputs (for each FPR if applicable).
     success = True

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -262,17 +262,8 @@ def compute_output_denoised_counts_reports_metrics(
     elif args.estimator == "mckp" or args.estimator == "fast-mckp":
         if args.estimator == "mckp":
             estimator = MultipleChoiceKnapsack
-
-            use_cuda_compute_mean_device = "cuda"
         else: #args.estimator == "fast-mckp":
             estimator = MultipleChoiceKnapsackFast
-
-            # TODO: check to see if fast-MCKP is in GPU mode
-
-            # Disables GPU calculations here to save VRAM for fast-MCKP.
-            # Might instead be able to manually free memory after noise target computation, but
-            # there wasn't a noticeable performance difference.
-            use_cuda_compute_mean_device = "cpu"
 
         # Prep specific for MCKP: target estimation.
         logger.info("Computing target noise counts per gene for MCKP estimator")
@@ -287,7 +278,7 @@ def compute_output_denoised_counts_reports_metrics(
             index_converter=posterior.index_converter,
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
-            device=use_cuda_compute_mean_device if args.use_cuda else "cpu",  # TODO check this
+            device="cuda" if args.use_cuda else "cpu",  # TODO check this
             per_gene=True,
         )
 

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -27,7 +27,7 @@ from cellbender.remove_background.data.dataprep import prep_sparse_data_for_trai
 from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset, get_dataset_obj
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
 from cellbender.remove_background.estimation import MAP, Mean, MultipleChoiceKnapsack, MultipleChoiceKnapsackFast, \
-    SingleSample, ThresholdCDF
+    MultipleChoiceKnapsackFast2, SingleSample, ThresholdCDF
 from cellbender.remove_background.exceptions import ElboException
 from cellbender.remove_background.model import RemoveBackgroundPyroModel
 from cellbender.remove_background.posterior import (
@@ -259,11 +259,13 @@ def compute_output_denoised_counts_reports_metrics(
         estimator = SingleSample
     elif args.estimator == "cdf":
         estimator = ThresholdCDF
-    elif args.estimator == "mckp" or args.estimator == "fast-mckp":
+    elif args.estimator == "mckp" or args.estimator == "fast-mckp" or args.estimator == "fast-mckp2":
         if args.estimator == "mckp":
             estimator = MultipleChoiceKnapsack
-        else: #args.estimator == "fast-mckp":
+        elif args.estimator == "fast-mckp":
             estimator = MultipleChoiceKnapsackFast
+        else:
+            estimator = MultipleChoiceKnapsackFast2
 
         # Prep specific for MCKP: target estimation.
         logger.info("Computing target noise counts per gene for MCKP estimator")
@@ -285,7 +287,7 @@ def compute_output_denoised_counts_reports_metrics(
         def noise_target_fun(x):
             return noise_target_fun_per_cell(x) * len(cell_inds)
     else:
-        raise ValueError('Input --estimator must be one of ["map", "mean", "sample", "cdf", "mckp", "fast-mckp"]')
+        raise ValueError('Input --estimator must be one of ["map", "mean", "sample", "cdf", "mckp", "fast-mckp", "fast-mckp2"]')
 
     # Save denoised count matrix outputs (for each FPR if applicable).
     success = True

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -27,8 +27,8 @@ from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.data.dataprep import prep_sparse_data_for_training as prep_data_for_training
 from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset, get_dataset_obj
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
-from cellbender.remove_background.estimation import MAP, Mean, MultipleChoiceKnapsack, MultipleChoiceKnapsackFast, \
-    SingleSample, ThresholdCDF
+from cellbender.remove_background.estimation import MAP, Mean, MeanFast, MultipleChoiceKnapsack, \
+    MultipleChoiceKnapsackFast, SingleSample, ThresholdCDF
 from cellbender.remove_background.exceptions import ElboException
 from cellbender.remove_background.model import RemoveBackgroundPyroModel
 from cellbender.remove_background.posterior import (
@@ -264,8 +264,10 @@ def compute_output_denoised_counts_reports_metrics(
         estimator = ThresholdCDF
     elif args.estimator == "mckp" or args.estimator == "fast-mckp":
         if args.estimator == "mckp":
+            target_estimator = Mean
             estimator = MultipleChoiceKnapsack
-        else: #args.estimator == "fast-mckp":
+        else:  # args.estimator == "fast-mckp":
+            target_estimator = MeanFast
             estimator = MultipleChoiceKnapsackFast
 
         # Prep specific for MCKP: target estimation.
@@ -278,7 +280,7 @@ def compute_output_denoised_counts_reports_metrics(
         noise_target_fun_per_cell = compute_mean_target_removal_as_function(
             noise_count_posterior_coo=posterior._noise_count_posterior_coo,
             noise_offsets=posterior._noise_count_posterior_coo_offsets,
-            index_converter=posterior.index_converter,
+            target_estimator=target_estimator(index_converter=posterior.index_converter),
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
             device="cuda" if args.use_cuda else "cpu",  # TODO check this

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -262,8 +262,17 @@ def compute_output_denoised_counts_reports_metrics(
     elif args.estimator == "mckp" or args.estimator == "fast-mckp":
         if args.estimator == "mckp":
             estimator = MultipleChoiceKnapsack
-        elif args.estimator == "fast-mckp":
+
+            use_cuda_compute_mean_device = "cuda"
+        else: #args.estimator == "fast-mckp":
             estimator = MultipleChoiceKnapsackFast
+
+            # TODO: check to see if fast-MCKP is in GPU mode
+
+            # Disables GPU calculations here to save VRAM for fast-MCKP.
+            # Might instead be able to manually free memory after noise target computation, but
+            # there wasn't a noticeable performance difference.
+            use_cuda_compute_mean_device = "cpu"
 
         # Prep specific for MCKP: target estimation.
         logger.info("Computing target noise counts per gene for MCKP estimator")
@@ -278,7 +287,7 @@ def compute_output_denoised_counts_reports_metrics(
             index_converter=posterior.index_converter,
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
-            device="cuda" if args.use_cuda else "cpu",  # TODO check this
+            device=use_cuda_compute_mean_device if args.use_cuda else "cpu",  # TODO check this
             per_gene=True,
         )
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -187,8 +187,12 @@ def test_single_sample(log_prob_coo):
         print(out_per_m[i])
         assert out_per_m[i] in allowed_vals, f"sample {out_per_m[i]} is not allowed for {dense[i, :]}"
 
-
-def test_mean(log_prob_coo):
+@pytest.mark.parametrize(
+    "device",
+    ("cpu", "cuda"),
+    ids=["cpu", "cuda"],
+)
+def test_mean(log_prob_coo, device):
     """Test the mean estimator"""
 
     def _add_offsets_to_truth(truth: np.ndarray, offset_dict: Dict[int, int]):
@@ -207,7 +211,7 @@ def test_mean(log_prob_coo):
 
     # set up and estimate
     estimator = Mean(index_converter=converter)
-    noise_csr = estimator.estimate_noise(noise_log_prob_coo=log_prob_coo["coo"], noise_offsets=offset_dict)
+    noise_csr = estimator.estimate_noise(noise_log_prob_coo=log_prob_coo["coo"], noise_offsets=offset_dict, device=device)
 
     # output
     print("dense noise count estimate, per m")


### PR DESCRIPTION
Note: I accidentally hit the merge button when looking at the diff, so this whole thing is somewhat half-cooked and should definitely not be merged. However, I would like to gauge interest in the changes I've made, so I'm leaving it up.

# Summary
This PR is a proof-of-concept rewrite of the Mean and MultipleChoiceKnapsack EstimationMethods. On my system ( using the --cuda and --estimator-multiple-cpu arguments) the time taken to estimate noise targets and compute denoised counts is greatly reduced. When applied to the heart10k dataset, this implementation takes ~8 seconds, compared to the main branch at ~60s, and the sf-modernization-estimation branch at ~40s.

I will note that most of the speedup vs the sf-modernization-estimation branch comes from the improved mean estimator, whereas MCKP is only slightly faster here.

# Mean Estimator
I use the inverse indices returned by torch.unique(noise_log_prob_coo.row, return_inverse=True) to group the indices into noise_log_prob_coo according to the m-index value. Then torch.bincounts gets a weighted sum of probability * c within each group.

This can be applied to the entire posterior, without chunking or densifying, and works seamlessly with either CPU (runtime 1.5s) or GPU (runtime 0.68s) tensors. Compare with the original at ~30s.

As far as correctness goes, it needs more testing for sure, but tentatively looks OK. All tests pass, and I compared the sum of all estimated counts and found a difference on the order of 10<sup>-6</sup> percent, presumably due to floating-point arithmetic differences.

# MCKP Estimator
My goal here was to remove the pandas dataframes. As soon as I saw them, I had some flashbacks to the time I tried to implement XGBoost in dataframes, which, performance-wise, did not go well :melting_face:. Unfortunately, I hadn't seen the work already done in the modernization branch, which is probably a better solution. But, if you want to avoid adding dependencies, I have an alternative.

### Algorithm Overview
Similarly to the mean estimator, torch.unique inverse indices are used to group the posterior COO, but this time according the the gene. Genes with zero probability are excluded, then genes are iterated on as follows:

1. A dense 2D tensor is created by subsetting the COO to the current gene and removing cells with zero probability. Great care was taken to minimize the size and the number of these tensors before proceeding to the next step.
2. The MAP solution is iteratively improved as in the CellBender paper. Note that I have probably missed some corner cases here, so my implementation currently deviates somewhat from the original.
Here is one of the original output plots:
<img width="1198" height="534" alt="image" src="https://github.com/user-attachments/assets/c76c7b27-aded-4ee7-89af-3624b9c559ea" />
And here is mine: 
<img width="1198" height="534" alt="image" src="https://github.com/user-attachments/assets/10c8f101-9543-41ff-a630-dd9a5a3b5f37" />



3. The indices of the solutions are used to construct the final CSR matrix and we're done.

This loop can be run on the GPU, but is slow. As such, I only run the initial grouping step on the GPU.



### Some Thoughts on Multiprocessing
If use_multiple_processes=True, this iterative method is easy enough to chunk. The challenge lies in efficient inter-process communication. In fact, the original MultipleChoiceKnapsack.estimate_noise has a comment that mentions multiprocessing causes a slowdown (which on my PC is not true, but it is still slower than it could be). This is because each argument to _mckp_chunk_estimate_noise must be pickled and copied into each child process.

The solution to this is to load the arguments into shared memory. For arbitrary objects, this is tedious but doable, and leads to moderate speedups. Check out my early commits if you want to see an admittedly very ugly example.

Luckily, torch.multiprocessing exists: its a wrapper around the python multiprocessing library that automatically handles tensor shared memory management. In a single process, I see MCKP estimation taking ~10s, but with 14 processes, it takes ~3s.

Finding the optimal number of processes and threads per process to use still needs work and currently will require individual tuning via some hardcoded variables. By default, torch uses the number of physical cores, which in my case is 14. If you launch 6 processes, that is 84 threads competing for resources. In my testing, when using multiple processes, it it best to limit each to a single thread.

Determining the total number of processes is also an issue. On linux, I find that using the number of physical cores is best, but on Windows, using approx. half as many works better. I'm assuming this is due to increased overhead from spawning processes on Windows compared to forking on linux.

# Closing Notes
Like I said earlier, I didn't intended for the world to see this code in its current state, so please don't judge it too harshly. Hopefully at least some of it will prove useful. Either way, I fun writing it and learned a lot in the process! Let me know if you want me to clean any of it up and I can submit a new PR. 

