### PR TITLE
`h5ad` support

### DIFF
--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -50,6 +50,13 @@ def add_subparser_args(subparsers: argparse._SubParsersAction) -> argparse._SubP
         help="Output file location (the path must exist, and the file name must have .h5 extension).",
     )
     subparser.add_argument(
+        "--no-h5ad",
+        dest="output_h5ad",
+        action="store_false",
+        default=True,
+        help="By default, output is saved in h5ad format. Use --no-h5ad to disable this.",
+    )
+    subparser.add_argument(
         "--cuda",
         dest="use_cuda",
         action="store_true",

--- a/cellbender/remove_background/data/io.py
+++ b/cellbender/remove_background/data/io.py
@@ -221,6 +221,44 @@ def write_matrix_to_cellranger_h5(
     return True
 
 
+def save_h5ad_from_h5(h5_file: str,
+                      analyzed_barcodes_only: bool) -> bool:
+    """Convert a CellBender output h5 file to h5ad format.
+
+    Load the h5 file using anndata_from_h5() and
+    resave as h5ad.
+
+    Args:
+        h5_file: Path to a CellBender output .h5 file.
+        analyzed_barcodes_only: True to include only barcodes
+        that were analyzed (for filtered output files). 
+        False to include all barcodes (for full output files).
+
+    Returns:
+        True if the h5ad file was written successfully, False otherwise.
+
+    """
+
+    # import placed here to avoid circular dependency (downstream imports from io).
+    from cellbender.remove_background.downstream import anndata_from_h5
+
+    h5ad_file = os.path.splitext(h5_file)[0] + '.h5ad'
+
+    try:
+        adata = anndata_from_h5(
+            h5_file,
+            analyzed_barcodes_only=analyzed_barcodes_only,
+        )
+        adata.write_h5ad(h5ad_file)
+        logger.info(f"Saved h5ad output as {h5ad_file}")
+        return True
+
+    except Exception:
+        logger.warning(f"Unable to save h5ad output as {h5ad_file}")
+        logger.warning(traceback.format_exc())
+        return False
+
+
 def write_posterior_coo_to_h5(
         output_file: str,
         posterior_coo: sp.coo_matrix,

--- a/cellbender/remove_background/downstream.py
+++ b/cellbender/remove_background/downstream.py
@@ -80,7 +80,6 @@ def anndata_from_h5(file: str, analyzed_barcodes_only: bool = True) -> anndata.A
         X=X,
         obs={"barcode": d.pop("barcodes").astype(str)},
         var={"gene_name": (d.pop("gene_names") if "gene_names" in d.keys() else d.pop("name")).astype(str)},
-        dtype=X.dtype,
     )
     adata.obs.set_index("barcode", inplace=True)
     adata.var.set_index("gene_name", inplace=True)
@@ -191,7 +190,6 @@ def load_anndata_from_input(input_file: str) -> anndata.AnnData:
         X=d.pop("matrix"),
         obs={"barcode": barcodes.astype(str)},
         var={"gene_name": gene_names.astype(str)},
-        dtype=int,
     )
     adata.obs.set_index("barcode", inplace=True)
     adata.var.set_index("gene_name", inplace=True)

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -25,7 +25,7 @@ from cellbender.remove_background.checkpoint import attempt_load_checkpoint, cre
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.data.dataprep import prep_sparse_data_for_training as prep_data_for_training
 from cellbender.remove_background.data.dataset import SingleCellRNACountsDataset, get_dataset_obj
-from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
+from cellbender.remove_background.data.io import save_h5ad_from_h5, write_matrix_to_cellranger_h5
 from cellbender.remove_background.estimation import MAP, Mean, MultipleChoiceKnapsack, SingleSample, ThresholdCDF
 from cellbender.remove_background.exceptions import ElboException
 from cellbender.remove_background.model import RemoveBackgroundPyroModel
@@ -182,11 +182,14 @@ def run_remove_background(args: argparse.Namespace) -> Posterior:
         file_name = os.path.splitext(os.path.basename(file_base))[0]
         filtered_file = os.path.join(file_dir, file_name + "_filtered.h5")
 
-        if os.path.exists(full_file):
-            os.remove(full_file)
-
-        if os.path.exists(filtered_file):
-            os.remove(filtered_file)
+        for f in [
+            full_file,
+            filtered_file,
+            os.path.splitext(full_file)[0] + ".h5ad",
+            os.path.splitext(filtered_file)[0] + ".h5ad",
+        ]:
+            if os.path.exists(f):
+                os.remove(f)
 
         logger.info("Keyboard interrupt.  Terminated without saving.\n")
         sys.exit(1)
@@ -369,6 +372,11 @@ def compute_output_denoised_counts_reports_metrics(
             barcode_inds=posterior.dataset_obj.analyzed_barcode_inds[analyzed_barcode_logic],
         )
         success = success and write_succeeded
+
+        # Save h5ad copies of the output files.
+        if args.output_h5ad:
+            save_h5ad_from_h5(fpr_output_filename, analyzed_barcodes_only=False)
+            save_h5ad_from_h5(filtered_output_file, analyzed_barcodes_only=True)
 
         # Compile and save metrics.
         try:


### PR DESCRIPTION
resolves #453 

support for `CellBender` to output an `h5ad` file , users can load results into an `AnnData` object using `anndata.read_h5ad()`.

changes:
1. `--no-h5ad` flag in `argparser.py` : the .h5ad generation enabled by default, can be disabled by this flag
2. load the written `.h5` output using `anndata_from_h5()` to write the `h5ad` and save using `adata.write_h5ad()`
3. `anndata` constructor (for ver 0.9+ : also in the requirements.txt) does not accept the dtype keyword (known automatically from X) was removed.