### PR TITLE
Add MPS (Apple Silicon GPU) support alongside CUDA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,10 @@ Ensure that your installation is appropriate for your hardware (i.e. that
 the relevant CUDA drivers get installed and that ``torch.cuda.is_available()``
 returns ``True`` if you have a GPU available.
 
+On an Apple Silicon Mac there are no drivers to install, and
+``torch.backends.mps.is_available()`` should return ``True``. Pass ``--mps``
+instead of ``--cuda`` to run on the integrated GPU.
+
 This installs CellBender with dev dependencies (in editable ``-e`` mode):
 
 

--- a/cellbender/base_cli.py
+++ b/cellbender/base_cli.py
@@ -12,6 +12,8 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _importlib_version
 from typing import Dict
 
+from cellbender.device import maybe_enable_mps_fallback
+
 # New tools should be added to this list.
 TOOL_NAME_LIST = ["remove-background"]
 
@@ -99,12 +101,18 @@ def main():
 
     """
 
+    # This has to happen before generate_cli_dictionary(), which imports the tool
+    # CLI modules, which import torch. Enabling the MPS CPU fallback after torch
+    # has been imported has no effect.
+    mps_fallback_enabled = maybe_enable_mps_fallback(sys.argv)
+
     parser = get_populated_argparser()
     cli_dict = generate_cli_dictionary()
 
     # Parse arguments.
     if len(sys.argv) > 1:
         args = parser.parse_args(sys.argv[1:])
+        args.mps_fallback_enabled = mps_fallback_enabled
 
         # Validate arguments.
         args = cli_dict[args.tool].validate_args(args)

--- a/cellbender/device.py
+++ b/cellbender/device.py
@@ -1,0 +1,205 @@
+"""Backend device selection and backend-specific helpers.
+
+CellBender can run on three PyTorch backends: CUDA, MPS (Apple Silicon GPUs, via
+Metal), and CPU. Everything that differs between them is collected here, so that
+the rest of the codebase only passes around a plain device string.
+
+This module deliberately does not import torch at module level. Enabling the MPS
+CPU fallback only takes effect if the environment variable is set before torch is
+first imported (see ``maybe_enable_mps_fallback``), and this module is imported
+from ``cellbender.base_cli`` for precisely that reason. Functions that need torch
+import it locally.
+"""
+
+import logging
+import os
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
+from typing import Any, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("cellbender")
+
+DEVICES = ("cpu", "cuda", "mps")
+
+MPS_FALLBACK_ENV_VAR = "PYTORCH_ENABLE_MPS_FALLBACK"
+
+# Metal kernels for aten::poisson and aten::binomial landed in torch after the
+# 2.13 branch cut, so from 2.14 onward every op CellBender uses has a native MPS
+# implementation and no CPU fallback is needed.
+FIRST_TORCH_VERSION_WITH_NATIVE_MPS_SAMPLING = (2, 14)
+
+
+def _installed_torch_version() -> Optional[Tuple[int, ...]]:
+    """Read the installed torch version without importing torch.
+
+    Returns None if torch is not installed or the version is unparseable.
+    """
+    try:
+        raw = _package_version("torch")
+    except PackageNotFoundError:
+        return None
+
+    # Strip any local version label, e.g. "2.13.0+cu128".
+    numbers: List[int] = []
+    for chunk in raw.split("+")[0].split("."):
+        if not chunk.isdigit():
+            break
+        numbers.append(int(chunk))
+
+    return tuple(numbers) if numbers else None
+
+
+def torch_has_native_mps_sampling() -> bool:
+    """True if the installed torch has Metal kernels for every op we sample from."""
+    installed = _installed_torch_version()
+    if installed is None:
+        return False
+    return installed >= FIRST_TORCH_VERSION_WITH_NATIVE_MPS_SAMPLING
+
+
+def maybe_enable_mps_fallback(argv: Sequence[str]) -> bool:
+    """Turn on the MPS-to-CPU fallback for ops without a Metal kernel.
+
+    Must be called before anything imports torch: torch reads this environment
+    variable when it registers the MPS fallback kernel, so setting it afterwards
+    has no effect.
+
+    On torch < 2.14, ``aten::poisson`` and ``aten::binomial`` have no Metal
+    kernel, and CellBender samples from both. Those ops raise NotImplementedError
+    on MPS unless the fallback is enabled. From torch 2.14 the fallback is not
+    needed, and leaving it off means a future gap surfaces as a loud error rather
+    than as a silent slow path.
+
+    An explicit setting in the environment is always respected.
+
+    Args:
+        argv: Command line arguments, normally ``sys.argv``.
+
+    Returns:
+        True if the CPU fallback is enabled for this process.
+    """
+    if "--mps" not in argv:
+        return False
+
+    if MPS_FALLBACK_ENV_VAR in os.environ:
+        return os.environ[MPS_FALLBACK_ENV_VAR] == "1"
+
+    if torch_has_native_mps_sampling():
+        return False
+
+    os.environ[MPS_FALLBACK_ENV_VAR] = "1"
+    return True
+
+
+def resolve_device(use_cuda: bool, use_mps: bool) -> str:
+    """Pick the backend to run on, checking that it is actually usable.
+
+    Args:
+        use_cuda: True if the user passed --cuda.
+        use_mps: True if the user passed --mps.
+
+    Returns:
+        One of 'cuda', 'mps', 'cpu'.
+
+    Raises:
+        ValueError: If both backends are requested, or the requested one is
+            unavailable.
+    """
+    import torch
+
+    if use_cuda and use_mps:
+        raise ValueError("Specify at most one of --cuda and --mps.")
+
+    if use_cuda:
+        if not torch.cuda.is_available():
+            raise ValueError("Trying to use CUDA, but CUDA is not available.")
+        return "cuda"
+
+    if use_mps:
+        if not torch.backends.mps.is_built():
+            raise ValueError("Trying to use MPS, but this PyTorch installation was not built with MPS enabled.")
+        if not torch.backends.mps.is_available():
+            raise ValueError(
+                "Trying to use MPS, but no MPS-enabled device is available. "
+                "MPS requires macOS 12.3 or later on Apple Silicon."
+            )
+        return "mps"
+
+    return "cpu"
+
+
+def available_devices() -> List[str]:
+    """Backends usable on this machine, fastest first. CPU is always included."""
+    import torch
+
+    devices = []
+    if torch.cuda.is_available():
+        devices.append("cuda")
+    if torch.backends.mps.is_available():
+        devices.append("mps")
+    devices.append("cpu")
+    return devices
+
+
+def seed_all(seed: int, device: str) -> None:
+    """Seed the RNG of the host and of the given backend."""
+    import torch
+
+    torch.manual_seed(seed)
+    if device == "cuda":
+        torch.cuda.manual_seed_all(seed)
+    elif device == "mps":
+        torch.mps.manual_seed(seed)
+
+
+def get_device_rng_state(device: str) -> Optional[Any]:
+    """Return the backend RNG state, or None for backends that have none of their own."""
+    import torch
+
+    if device == "cuda":
+        return torch.cuda.get_rng_state_all()
+    if device == "mps":
+        return torch.mps.get_rng_state()
+    return None
+
+
+def set_device_rng_state(device: str, state: Any) -> None:
+    """Restore a backend RNG state produced by :func:`get_device_rng_state`."""
+    import torch
+
+    if device == "cuda":
+        torch.cuda.set_rng_state_all(state)
+    elif device == "mps":
+        torch.mps.set_rng_state(state)
+
+
+def empty_cache(device: str) -> None:
+    """Release cached device memory back to the driver."""
+    import torch
+
+    if device == "cuda":
+        torch.cuda.empty_cache()
+    elif device == "mps":
+        torch.mps.empty_cache()
+
+
+def checkpoint_map_location(device: str) -> str:
+    """Device string to load a checkpoint onto."""
+    return "cuda:0" if device == "cuda" else device
+
+
+def supports_float64(device: str) -> bool:
+    """False for MPS: Metal Shading Language has no double type.
+
+    This is a hardware limitation rather than a missing kernel, so
+    PYTORCH_ENABLE_MPS_FALLBACK does not work around it. Computations that would
+    normally use float64 run in float32 on MPS.
+    """
+    return device != "mps"
+
+
+def float_dtype(device: str) -> Any:
+    """Widest float dtype the backend supports."""
+    import torch
+
+    return torch.float32 if device == "mps" else torch.float64

--- a/cellbender/monitor.py
+++ b/cellbender/monitor.py
@@ -12,12 +12,16 @@ import torch
 from psutil._common import bytes2human
 
 
-def get_hardware_usage(use_cuda: bool) -> str:
-    """Get a current snapshot of RAM, CPU, GPU memory, and GPU utilization as a string"""
+def get_hardware_usage(device: str) -> str:
+    """Get a current snapshot of RAM, CPU, GPU memory, and GPU utilization as a string
+
+    Args:
+        device: Backend in use, one of 'cpu', 'cuda', 'mps'.
+    """
 
     mem = psutil.virtual_memory()
 
-    if use_cuda:
+    if device == "cuda":
         # Run nvidia-smi to get GPU utilization
         gpu_query = "utilization.gpu"
         format = "csv,nounits,noheader"
@@ -33,6 +37,13 @@ def get_hardware_usage(use_cuda: bool) -> str:
             f"Volatile GPU utilization: {pct_gpu_util} %\n"
             f"GPU memory reserved: {torch.cuda.memory_reserved() / 1e9} GB\n"
             f"GPU memory allocated: {torch.cuda.memory_allocated() / 1e9} GB\n"
+        )
+    elif device == "mps":
+        # Metal has no per-process utilization counter comparable to nvidia-smi,
+        # so report the two memory figures torch.mps exposes.
+        gpu_string = (
+            f"GPU memory reserved: {torch.mps.driver_allocated_memory() / 1e9} GB\n"
+            f"GPU memory allocated: {torch.mps.current_allocated_memory() / 1e9} GB\n"
         )
     else:
         gpu_string = ""

--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -49,11 +49,20 @@ def add_subparser_args(subparsers: argparse._SubParsersAction) -> argparse._SubP
         required=True,
         help="Output file location (the path must exist, and the file name must have .h5 extension).",
     )
-    subparser.add_argument(
+    device_group = subparser.add_mutually_exclusive_group()
+    device_group.add_argument(
         "--cuda",
         dest="use_cuda",
         action="store_true",
-        help="Including the flag --cuda will run the inference on a GPU.",
+        help="Including the flag --cuda will run the inference on an NVIDIA GPU.",
+    )
+    device_group.add_argument(
+        "--mps",
+        dest="use_mps",
+        action="store_true",
+        help="Including the flag --mps will run the inference on an Apple Silicon "
+        "GPU via Metal Performance Shaders. Requires macOS 12.3 or later. "
+        "See https://pytorch.org/docs/stable/notes/mps.html",
     )
     subparser.add_argument(
         "--checkpoint",

--- a/cellbender/remove_background/checkpoint.py
+++ b/cellbender/remove_background/checkpoint.py
@@ -20,6 +20,7 @@ import dill
 import numpy as np
 import torch
 
+from cellbender.device import get_device_rng_state, set_device_rng_state
 from cellbender.remove_background import consts
 from cellbender.remove_background.data.dataprep import DataLoader
 
@@ -30,18 +31,37 @@ try:
     import pyro
 except ImportError:
     USE_PYRO = False
-USE_CUDA = torch.cuda.is_available()
 
 
-def save_random_state(filebase: str) -> List[str]:
+def _device_of(force_device: Optional[str]) -> str:
+    """Normalize a device string such as 'cuda:0' to a bare backend name.
+
+    Falls back to whichever accelerator is present when nothing is specified.
+    """
+    if force_device is not None:
+        return force_device.split(":")[0]
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def save_random_state(filebase: str, device: Optional[str] = None) -> List[str]:
     """Write states of various random number generators to files.
 
     NOTE: the pyro.util.get_rng_state() is a compilation of python, numpy, and
         torch random states.  Here, we save the three explicitly ourselves.
         This is useful for potential future usages outside of pyro.
+
+    Args:
+        filebase: Path prefix shared by the state files.
+        device: Backend whose RNG state should also be saved. Defaults to
+            whichever accelerator is available.
     """
     # https://stackoverflow.com/questions/32808686/storing-a-random-state/32809283
 
+    device = _device_of(device)
     file_dict = {}
 
     # Random state information
@@ -59,9 +79,9 @@ def save_random_state(filebase: str) -> List[str]:
                 filebase + "_random.torch": torch_random_state,
             }
         )
-    if USE_CUDA:
-        cuda_random_state = torch.cuda.get_rng_state_all()
-        file_dict.update({filebase + "_random.cuda": cuda_random_state})
+    device_random_state = get_device_rng_state(device)
+    if device_random_state is not None:
+        file_dict.update({filebase + f"_random.{device}": device_random_state})
 
     # Save it
     for file, state in file_dict.items():
@@ -71,8 +91,16 @@ def save_random_state(filebase: str) -> List[str]:
     return list(file_dict.keys())
 
 
-def load_random_state(filebase: str):
-    """Load random states from files and update generators with them."""
+def load_random_state(filebase: str, device: Optional[str] = None):
+    """Load random states from files and update generators with them.
+
+    Args:
+        filebase: Path prefix shared by the state files.
+        device: Backend whose RNG state should also be restored. Defaults to
+            whichever accelerator is available.
+    """
+
+    device = _device_of(device)
 
     if USE_PYRO:
         with open(filebase + "_random.pyro", "rb") as f:
@@ -92,10 +120,13 @@ def load_random_state(filebase: str):
             torch_random_state = pickle.load(f)
         torch.set_rng_state(torch_random_state)
 
-    if USE_CUDA:
-        with open(filebase + "_random.cuda", "rb") as f:
-            cuda_random_state = pickle.load(f)
-        torch.cuda.set_rng_state_all(cuda_random_state)
+    # A checkpoint written on a machine without an accelerator has no device RNG
+    # state to restore, so tolerate its absence rather than failing the resume.
+    device_state_file = filebase + f"_random.{device}"
+    if os.path.exists(device_state_file):
+        with open(device_state_file, "rb") as f:
+            device_random_state = pickle.load(f)
+        set_device_rng_state(device, device_random_state)
 
 
 def save_checkpoint(
@@ -118,7 +149,7 @@ def save_checkpoint(
             basename = os.path.basename(filebase)
             filebase = os.path.join(tmp_dir, basename)
 
-            file_list = save_random_state(filebase=filebase)
+            file_list = save_random_state(filebase=filebase, device=model_obj.device)
 
             torch.save(model_obj, filebase + "_model.torch", pickle_module=dill)
             torch.save(scheduler, filebase + "_optim.torch", pickle_module=dill)
@@ -270,8 +301,8 @@ def load_from_checkpoint(
 
         # Update states of random number generators across the board.
         if "random_state" in to_load:
-            load_random_state(filebase=filebase)
-            logger.debug("Loaded random state globally for python, numpy, pytorch, and cuda")
+            load_random_state(filebase=filebase, device=force_device)
+            logger.debug("Loaded random state globally for python, numpy, pytorch, and the accelerator")
 
         # Copy the posterior file outside the temp dir so it can be loaded later.
         if "posterior" in to_load:

--- a/cellbender/remove_background/cli.py
+++ b/cellbender/remove_background/cli.py
@@ -113,8 +113,9 @@ class CLI(AbstractCLI):
                 )
                 sys.stdout.flush()  # Write immediately
             sys.stdout.write(
-                "Note: MPS supports float32 only, so posterior estimation runs at "
-                "reduced precision compared to CUDA or CPU.\n\n"
+                "Note: MPS has no double precision, so posterior estimation runs in "
+                "float32 rather than float64, at reduced precision compared to CUDA "
+                "or CPU.\n\n"
             )
             sys.stdout.flush()  # Write immediately
 

--- a/cellbender/remove_background/cli.py
+++ b/cellbender/remove_background/cli.py
@@ -112,12 +112,6 @@ class CLI(AbstractCLI):
                     f"or later removes the need for the fallback.\n\n"
                 )
                 sys.stdout.flush()  # Write immediately
-            sys.stdout.write(
-                "Note: MPS has no double precision, so posterior estimation runs in "
-                "float32 rather than float64, at reduced precision compared to CUDA "
-                "or CPU.\n\n"
-            )
-            sys.stdout.flush()  # Write immediately
 
         # Make sure n_threads makes sense.
         if args.n_threads is not None:

--- a/cellbender/remove_background/cli.py
+++ b/cellbender/remove_background/cli.py
@@ -8,6 +8,11 @@ import sys
 import torch
 
 from cellbender.base_cli import AbstractCLI, get_version
+from cellbender.device import (
+    FIRST_TORCH_VERSION_WITH_NATIVE_MPS_SAMPLING,
+    MPS_FALLBACK_ENV_VAR,
+    resolve_device,
+)
 from cellbender.remove_background.posterior import Posterior
 from cellbender.remove_background.run import run_remove_background
 
@@ -75,11 +80,12 @@ class CLI(AbstractCLI):
         assert args.training_fraction > 0, "training-fraction must be > 0"
         assert args.training_fraction <= 1.0, "training-fraction must be <= 1"
 
-        # If cuda is requested, make sure it is available.
-        if args.use_cuda:
-            assert torch.cuda.is_available(), "Trying to use CUDA, but CUDA is not available."
-        else:
-            # Warn the user in case the CUDA flag was forgotten by mistake.
+        # Determine the backend to run on, checking that it is available.
+        args.device = resolve_device(use_cuda=args.use_cuda, use_mps=args.use_mps)
+
+        if args.device == "cpu":
+            # Warn the user in case the device flag was forgotten by mistake.
+            # CUDA takes priority over MPS when both are present.
             if torch.cuda.is_available():
                 sys.stdout.write(
                     "Warning: CUDA is available, but will not be "
@@ -87,6 +93,30 @@ class CLI(AbstractCLI):
                     "significant speed-ups.\n\n"
                 )
                 sys.stdout.flush()  # Write immediately
+            elif torch.backends.mps.is_available():
+                sys.stdout.write(
+                    "Warning: an Apple Silicon GPU (MPS) is available, but "
+                    "will not be used.  Use the flag --mps for "
+                    "significant speed-ups.\n\n"
+                )
+                sys.stdout.flush()  # Write immediately
+
+        if args.device == "mps":
+            if getattr(args, "mps_fallback_enabled", False):
+                sys.stdout.write(
+                    f"Note: torch {torch.__version__} has no Metal kernel for some "
+                    f"sampling operations, so {MPS_FALLBACK_ENV_VAR}=1 has been set "
+                    f"and those operations will run on the CPU. This is still faster "
+                    f"than running everything on the CPU. Upgrading to torch "
+                    f"{'.'.join(str(n) for n in FIRST_TORCH_VERSION_WITH_NATIVE_MPS_SAMPLING)} "
+                    f"or later removes the need for the fallback.\n\n"
+                )
+                sys.stdout.flush()  # Write immediately
+            sys.stdout.write(
+                "Note: MPS supports float32 only, so posterior estimation runs at "
+                "reduced precision compared to CUDA or CPU.\n\n"
+            )
+            sys.stdout.flush()  # Write immediately
 
         # Make sure n_threads makes sense.
         if args.n_threads is not None:

--- a/cellbender/remove_background/data/dataprep.py
+++ b/cellbender/remove_background/data/dataprep.py
@@ -59,7 +59,7 @@ class DataLoader:
                  fraction_empties: float = consts.FRACTION_EMPTIES,
                  shuffle: bool = True,
                  sort_by: Optional[Callable[[sp.csr_matrix], np.ndarray]] = None,
-                 use_cuda: bool = True):
+                 device: str = 'cpu'):
         """
         Args:
             dataset: Droplet count matrix [cell, gene]
@@ -73,7 +73,7 @@ class DataLoader:
                 the dataset. Dataloader will load data in order of increasing
                 values. Object attributes sort_order and unsort_order will be
                 made available.
-            use_cuda: True to load data to GPU
+            device: Backend to load data onto, one of 'cpu', 'cuda', 'mps'
         """
         if shuffle:
             assert sort_by is None, 'Cannot sort_by and shuffle at the same time'
@@ -98,10 +98,7 @@ class DataLoader:
         self.fraction_empties = fraction_empties
         self.cell_batch_size = int(batch_size * (1. - fraction_empties))
         self.shuffle = shuffle
-        self.device = 'cpu'
-        self.use_cuda = use_cuda
-        if self.use_cuda:
-            self.device = 'cuda'
+        self.device = device
         self._length = None
         self._reset()
 
@@ -199,7 +196,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
                                   fraction_empties: float = consts.FRACTION_EMPTIES,
                                   batch_size: int = consts.DEFAULT_BATCH_SIZE,
                                   shuffle: bool = True,
-                                  use_cuda: bool = True) -> Tuple[
+                                  device: str = 'cpu') -> Tuple[
                                       "DataLoader",
                                       "DataLoader"]:
     """Create torch.utils.data.DataLoaders for train and tests set.
@@ -222,7 +219,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
         batch_size: Number of cell barcodes per mini-batch of data.
         shuffle: Passed as an argument to torch.utils.data.DataLoader.  If
             True, the data is reshuffled at every epoch.
-        use_cuda: If True, the data loader will load tensors on GPU.
+        device: Backend to load tensors onto, one of 'cpu', 'cuda', 'mps'.
 
     Returns:
         train_loader: torch.utils.data.DataLoader object for training set.
@@ -257,7 +254,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
                               batch_size=batch_size,
                               fraction_empties=fraction_empties,
                               shuffle=shuffle,
-                              use_cuda=use_cuda)
+                              device=device)
 
     # Set up test dataloader.
     test_dataset = dataset[test_indices, ...]
@@ -267,7 +264,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
                              batch_size=batch_size,
                              fraction_empties=fraction_empties,
                              shuffle=shuffle,
-                             use_cuda=use_cuda)
+                             device=device)
 
     return train_loader, test_loader
 

--- a/cellbender/remove_background/data/dataset.py
+++ b/cellbender/remove_background/data/dataset.py
@@ -452,7 +452,7 @@ class SingleCellRNACountsDataset:
         return trimmed_matrix
 
     def get_dataloader(self,
-                       use_cuda: bool = True,
+                       device: str = 'cpu',
                        batch_size: int = 200,
                        shuffle: bool = False,
                        analyzed_bcs_only: bool = True,
@@ -461,7 +461,7 @@ class SingleCellRNACountsDataset:
         """Return a dataloader for the count matrix.
 
         Args:
-            use_cuda: Whether to load data into GPU memory.
+            device: Backend to load data onto, one of 'cpu', 'cuda', 'mps'.
             batch_size: Size of minibatch of data yielded by dataloader.
             shuffle: Whether dataloader should shuffle the data.
             analyzed_bcs_only: Only include the barcodes that have been
@@ -488,7 +488,7 @@ class SingleCellRNACountsDataset:
             fraction_empties=0.,
             shuffle=shuffle,
             sort_by=sort_by,
-            use_cuda=use_cuda,
+            device=device,
         )
         return data_loader
 

--- a/cellbender/remove_background/data/extras/simulate.py
+++ b/cellbender/remove_background/data/extras/simulate.py
@@ -1,5 +1,6 @@
 """Simulate a basic scRNA-seq count matrix dataset, for tests."""
 
+from cellbender.device import available_devices, seed_all
 from cellbender.remove_background.model import calculate_mu, calculate_lambda
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
 from cellbender.remove_background.checkpoint import load_from_checkpoint
@@ -19,24 +20,17 @@ if TYPE_CHECKING:
     from cellbender.remove_background.model import RemoveBackgroundPyroModel
 
 
-if torch.cuda.is_available():
-    USE_CUDA = True
-    DEVICE = 'cuda'
-else:
-    USE_CUDA = False
-    DEVICE = 'cpu'
+DEVICE = available_devices()[0]
 
 
-def comprehensive_random_seed(seed, use_cuda=USE_CUDA):
+def comprehensive_random_seed(seed, device=DEVICE):
     """Establish a base random state
     https://pytorch.org/docs/stable/notes/randomness.html
     """
     random.seed(seed)
     np.random.seed(seed)
-    torch.manual_seed(seed)
     pyro.util.set_rng_seed(seed)
-    if use_cuda:
-        torch.cuda.manual_seed_all(seed)
+    seed_all(seed, device)
 
 
 def generate_sample_inferred_model_dataset(
@@ -70,7 +64,7 @@ def generate_sample_inferred_model_dataset(
         filebase=None,
         tarball_name=checkpoint_file,
         to_load=['model', 'dataloader', 'param_store'],
-        force_device='cpu' if not torch.cuda.is_available() else None)
+        force_device=DEVICE)
     model = ckpt['model']
     n_genes = model.n_genes
 
@@ -82,16 +76,8 @@ def generate_sample_inferred_model_dataset(
 
     # Find z values for cells.
     data_loader = ckpt['train_loader']
-    if torch.cuda.is_available():
-        data_loader.use_cuda = True
-        data_loader.device = 'cuda'
-        model.use_cuda = True
-        model.device = 'cuda'
-    else:
-        data_loader.use_cuda = False
-        data_loader.device = 'cpu'
-        model.use_cuda = False
-        model.device = 'cpu'
+    data_loader.device = DEVICE
+    model.device = DEVICE
     z = np.zeros((len(data_loader), model.encoder['z'].output_dim))
     p = np.zeros(len(data_loader))
     chi_ambient = pyro.param('chi_ambient').detach()

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -17,6 +17,7 @@ import scipy.sparse as sp
 import torch
 from torch.distributions.categorical import Categorical
 
+from cellbender.device import float_dtype
 from cellbender.remove_background.sparse_utils import log_prob_sparse_to_dense
 
 logger = logging.getLogger("cellbender")
@@ -100,7 +101,7 @@ class SingleSample(EstimationMethod):
             noise_log_prob_coo: The noise log prob data structure: log prob
                 values in a (m, c) COO matrix
             noise_offsets: Noise count offset values keyed by 'm'.
-            device: ['cpu', 'cuda'] - whether to perform the pytorch sampling
+            device: ['cpu', 'cuda', 'mps'] - whether to perform the pytorch sampling
                 operation on CPU or GPU. It's pretty fast on CPU already.
 
         Returns:
@@ -134,7 +135,7 @@ class Mean(EstimationMethod):
         # c = torch.arange(noise_log_prob_coo.shape[1], dtype=float).to(device).t()
 
         def _torch_mean(x):
-            c = torch.arange(x.shape[1], dtype=float).to(x.device)
+            c = torch.arange(x.shape[1], dtype=x.dtype).to(x.device)
             return torch.matmul(x.exp(), c.t())
 
         result = apply_function_dense_chunks(noise_log_prob_coo=noise_log_prob_coo, fun=_torch_mean, device=device)
@@ -160,7 +161,7 @@ class MAP(EstimationMethod):
             noise_log_prob_coo: The noise log prob data structure: log prob
                 values in a (m, c) COO matrix
             noise_offsets: Noise count offset values keyed by 'm'.
-            device: ['cpu', 'cuda'] - whether to perform the pytorch argmax
+            device: ['cpu', 'cuda', 'mps'] - whether to perform the pytorch argmax
                 operation on CPU or GPU. It's pretty fast on CPU already.
 
         Returns:
@@ -759,7 +760,7 @@ def apply_function_dense_chunks(
             indexed by 'm' as rows
         fun: Pytorch function that operates on a dense tensor and produces
             one value per row
-        device: ['cpu', 'cuda'] - whether to perform the pytorch sampling
+        device: ['cpu', 'cuda', 'mps'] - whether to perform the pytorch sampling
             operation on CPU or GPU. It's pretty fast on CPU already.
         **kwargs: Passed to fun
 
@@ -776,7 +777,9 @@ def apply_function_dense_chunks(
     a = 0
 
     for coo, row, col in chunked_iterator(coo=noise_log_prob_coo):
-        dense_tensor = torch.tensor(log_prob_sparse_to_dense(coo)).to(device)
+        # The densified log probs are float64, which MPS cannot represent, so
+        # narrow to the widest float the backend supports before transferring.
+        dense_tensor = torch.tensor(log_prob_sparse_to_dense(coo), dtype=float_dtype(device)).to(device)
         if torch.numel(dense_tensor) == 0:
             # github issue 207
             continue

--- a/cellbender/remove_background/model.py
+++ b/cellbender/remove_background/model.py
@@ -94,7 +94,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         encoder: An instance of an encoder object.  Can be a CompositeEncoder.
         decoder: An instance of a decoder object.
         dataset_obj_priors: Dict which contains relevant priors.
-        use_cuda: Will use GPU if True.
+        device: Backend to run on, one of 'cpu', 'cuda', 'mps'.
         analyzed_gene_names: Here only so that when we save a checkpoint, if we
             ever want to look at it, we will know which genes are which.
         phi_loc_prior: Mean of gamma distribution for global overdispersion.
@@ -106,7 +106,7 @@ class RemoveBackgroundPyroModel(nn.Module):
 
     Attributes:
         All the above, plus
-        device: Either 'cpu' or 'cuda' depending on value of use_cuda.
+        device: The backend the model parameters live on.
         loss: Dict that records information about the loss during training.
 
     """
@@ -122,7 +122,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         analyzed_gene_names: np.ndarray,
         empty_UMI_threshold: int,
         log_counts_crossover: float,
-        use_cuda: bool,
+        device: str,
         phi_loc_prior: float = consts.PHI_LOC_PRIOR,
         phi_scale_prior: float = consts.PHI_SCALE_PRIOR,
         rho_alpha_prior: float = consts.RHO_ALPHA_PRIOR,
@@ -156,20 +156,17 @@ class RemoveBackgroundPyroModel(nn.Module):
         self.log_counts_crossover = log_counts_crossover
         self.counts_crossover = np.exp(log_counts_crossover)
 
-        # Determine whether we are working on a GPU.
-        if use_cuda:
-            # Calling cuda() here will put all the parameters of
+        # Move onto the GPU, if we are using one.
+        if device != "cpu":
+            # Calling to() here will put all the parameters of
             # the encoder and decoder networks into GPU memory.
-            self.cuda()
+            self.to(device)
             try:
                 for key, value in self.encoder.items():
-                    value.cuda()
+                    value.to(device)
             except KeyError:
                 pass
-            self.device = "cuda"
-        else:
-            self.device = "cpu"
-        self.use_cuda = use_cuda
+        self.device = device
 
         # Priors
         assert dataset_obj_priors["d_std"] > 0, (
@@ -257,7 +254,7 @@ class RemoveBackgroundPyroModel(nn.Module):
             phi = pyro.sample("phi", dist.Gamma(self.phi_conc_prior, self.phi_rate_prior))
 
         # Happens in parallel for each data point (cell barcode) independently:
-        with pyro.plate("data", x.shape[0], use_cuda=self.use_cuda, device=self.device):
+        with pyro.plate("data", x.shape[0], device=self.device):
             # Sample z from prior.
             z = pyro.sample(
                 "z", dist.Normal(loc=self.z_loc_prior, scale=self.z_scale_prior).expand_by([x.size(0)]).to_event(1)
@@ -518,7 +515,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         pyro.sample("phi", dist.Gamma(phi_conc, phi_rate))
 
         # Happens in parallel for each data point (cell barcode) independently:
-        with pyro.plate("data", x.shape[0], use_cuda=self.use_cuda, device=self.device):
+        with pyro.plate("data", x.shape[0], device=self.device):
             # Sample swapping fraction rho.
             if self.include_rho:
                 _rho = pyro.sample("rho", dist.Beta(rho_alpha, rho_beta).expand_by([x.size(0)]))

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -20,6 +20,7 @@ import scipy.sparse as sp
 import torch
 
 import cellbender.remove_background.consts as consts
+from cellbender.device import float_dtype
 from cellbender.monitor import get_hardware_usage
 from cellbender.remove_background.checkpoint import load_checkpoint, load_from_checkpoint, make_tarball, unpack_tarball
 from cellbender.remove_background.data.dataprep import DataLoader
@@ -212,8 +213,10 @@ class Posterior:
             encoder["z"].eval()
             encoder["other"].eval()
             vi_model.decoder.eval()
-        self.use_cuda = torch.cuda.is_available() if vi_model is None else vi_model.use_cuda
-        self.device = "cuda" if self.use_cuda else "cpu"
+        if vi_model is not None:
+            self.device = vi_model.device
+        else:
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.analyzed_gene_inds = None if (dataset_obj is None) else dataset_obj.analyzed_gene_inds
         if dataset_obj is not None and dataset_obj.data is not None:
             self.count_matrix_shape: tuple | None = dataset_obj.data["matrix"].shape
@@ -485,7 +488,7 @@ class Posterior:
             batch_size=self.posterior_batch_size,
             fraction_empties=0.0,
             shuffle=False,
-            use_cuda=self.use_cuda,
+            device=self.device,
         )
 
         bcs = []  # barcode index
@@ -515,7 +518,7 @@ class Posterior:
 
             if self.debug:
                 logger.debug(f"Posterior minibatch starting with droplet {ind}")
-                logger.debug("\n" + get_hardware_usage(use_cuda=self.use_cuda))
+                logger.debug("\n" + get_hardware_usage(device=self.device))
 
             # Compute noise count probabilities.
             noise_log_pdf_NGC, noise_count_offset_NG = self.noise_log_pdf(
@@ -869,7 +872,7 @@ class Posterior:
             return None
 
         data_loader = self.dataset_obj.get_dataloader(
-            use_cuda=self.use_cuda, analyzed_bcs_only=True, batch_size=500, shuffle=False
+            device=self.device, analyzed_bcs_only=True, batch_size=500, shuffle=False
         )
 
         n_analyzed = data_loader.dataset.shape[0]
@@ -1117,7 +1120,8 @@ class PRq(PosteriorRegularization):
         for i in range(n_chunks):
             # B index here represents a batch: the re-defined m-index
             log_pdf_noise_counts_BC = torch.tensor(
-                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)])
+                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)]),
+                dtype=float_dtype(device),
             ).to(device)
             noise_count_BC = (
                 torch.arange(log_pdf_noise_counts_BC.shape[1])
@@ -1210,7 +1214,7 @@ class PRq(PosteriorRegularization):
             noise_count_posterior_coo=noise_count_posterior_coo,
             alpha=alpha,
         )
-        log_target_M = torch.tensor(list(log_target_dict.values())).to(device)
+        log_target_M = torch.tensor(list(log_target_dict.values()), dtype=float_dtype(device)).to(device)
 
         reg_noise_count_posterior_coo = PRq._chunked_compute_regularized_posterior(
             noise_count_posterior_coo=noise_count_posterior_coo,
@@ -1341,7 +1345,8 @@ class PRmu(PosteriorRegularization):
         for i in range(n_chunks):
             # B index here represents a batch: the re-defined m-index
             log_pdf_noise_counts_BC = torch.tensor(
-                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)])
+                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)]),
+                dtype=float_dtype(device),
             ).to(device)
             noise_count_BC = (
                 torch.arange(log_pdf_noise_counts_BC.shape[1])
@@ -1645,7 +1650,7 @@ def compute_mean_target_removal_as_function(
             target = target + fpr * approx_signal_csr.sum()
 
         # Return target scaled to be per-cell.
-        return torch.tensor(target / n_cells).to(device)
+        return torch.tensor(target / n_cells, dtype=float_dtype(device)).to(device)
 
     return _target_fun
 

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -21,6 +21,7 @@ from pyro.optim import ClippedAdam
 
 import cellbender
 import cellbender.remove_background.consts as consts
+from cellbender.device import checkpoint_map_location, seed_all
 from cellbender.remove_background.checkpoint import attempt_load_checkpoint, create_workflow_hashcode, save_checkpoint
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.data.dataprep import prep_sparse_data_for_training as prep_data_for_training
@@ -92,8 +93,7 @@ def run_remove_background(args: argparse.Namespace) -> Posterior:
 
     # Handle initial random state.
     pyro.util.set_rng_seed(consts.RANDOM_SEED)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(consts.RANDOM_SEED)
+    seed_all(consts.RANDOM_SEED, args.device)
 
     # Load dataset, run inference, and write the output to a file.
 
@@ -102,7 +102,7 @@ def run_remove_background(args: argparse.Namespace) -> Posterior:
     logger.info("Running remove-background")
 
     # Run pytorch multithreaded if running on CPU: but this makes little difference in runtime.
-    if not args.use_cuda:
+    if args.device == "cpu":
         if args.n_threads is not None:
             n_jobs = args.n_threads
         else:
@@ -274,7 +274,7 @@ def compute_output_denoised_counts_reports_metrics(
             index_converter=posterior.index_converter,
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
-            device="cuda" if args.use_cuda else "cpu",  # TODO check this
+            device=args.device,  # TODO check this
             per_gene=True,
         )
 
@@ -296,7 +296,7 @@ def compute_output_denoised_counts_reports_metrics(
                 raw_count_matrix=posterior.dataset_obj.data["matrix"],
                 fpr=fpr,
                 per_gene=True if (args.posterior_regularization == "PRmu_gene") else False,
-                device="cuda",
+                device=args.device,
             )
         else:
             # Other posterior regularizations were already performed in
@@ -318,7 +318,7 @@ def compute_output_denoised_counts_reports_metrics(
             noise_targets_per_gene=noise_targets,
             q=args.cdf_threshold_q,
             alpha=args.prq_alpha,
-            device="cuda" if args.use_cuda else "cpu",
+            device=args.device,
             use_multiple_processes=args.use_multiprocessing_estimation,
         )
 
@@ -662,14 +662,13 @@ def run_inference(
     # Set random seed, updating global state of python, numpy, and torch RNGs.
     pyro.clear_param_store()
     pyro.set_rng_seed(consts.RANDOM_SEED)
-    if args.use_cuda:
-        torch.cuda.manual_seed_all(consts.RANDOM_SEED)
+    seed_all(consts.RANDOM_SEED, args.device)
 
     # Attempt to load from a previously-saved checkpoint.
     ckpt = attempt_load_checkpoint(
         filebase=checkpoint_filename,
         tarball_name=args.input_checkpoint_tarball,
-        force_device="cuda:0" if args.use_cuda else "cpu",
+        force_device=checkpoint_map_location(args.device),
         force_use_checkpoint=args.force_use_checkpoint,
     )
     ckpt_loaded = ckpt["loaded"]  # True if a checkpoint was loaded successfully
@@ -739,7 +738,7 @@ def run_inference(
             analyzed_gene_names=dataset_obj.data["gene_names"][dataset_obj.analyzed_gene_inds],
             empty_UMI_threshold=dataset_obj.empty_UMI_threshold,
             log_counts_crossover=dataset_obj.priors["log_counts_crossover"],
-            use_cuda=args.use_cuda,
+            device=args.device,
         )
 
         # Load the dataset into DataLoaders.
@@ -754,7 +753,7 @@ def run_inference(
             training_fraction=frac,
             fraction_empties=args.fraction_empties,
             shuffle=True,
-            use_cuda=args.use_cuda,
+            device=args.device,
         )
 
         # Set up optimizer (optionally wrapped in a learning rate scheduler).

--- a/cellbender/remove_background/train.py
+++ b/cellbender/remove_background/train.py
@@ -9,11 +9,11 @@ from typing import List, Tuple
 
 import numpy as np
 import pyro
-import torch
 from pyro.infer import SVI
 from pyro.util import ignore_jit_warnings
 
 import cellbender.remove_background.consts as consts
+from cellbender.device import empty_cache
 from cellbender.monitor import get_hardware_usage
 from cellbender.remove_background.checkpoint import save_checkpoint
 from cellbender.remove_background.data.dataprep import DataLoader
@@ -161,7 +161,7 @@ def run_training(
             if args.debug:
                 # Don't spend time pinging usage stats if we will not use the log.
                 # TODO: use multiprocessing to sample these stats DURING training...
-                logger.debug("\n" + get_hardware_usage(use_cuda=model.use_cuda))
+                logger.debug("\n" + get_hardware_usage(device=model.device))
 
             # Display duration of an epoch (use 2 to avoid initializations).
             if epoch == start_epoch + 1:
@@ -295,6 +295,6 @@ def run_training(
             )
 
     # Free up all the GPU memory we can once training is complete.
-    torch.cuda.empty_cache()
+    empty_cache(model.device)
 
     return train_elbo, model.loss["test"]["elbo"]

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -196,10 +196,11 @@ Considerations for setting parameters:
 * ``--cuda``: Include this flag.  The code is meant to be run on a GPU.
 * ``--mps``: Use this instead of ``--cuda`` on an Apple Silicon Mac, to run on the
   integrated GPU via Metal Performance Shaders.  Requires macOS 12.3 or later.
-  ``--cuda`` and ``--mps`` are mutually exclusive.  Note that Metal supports
-  float32 only, so posterior estimation runs at lower precision than it does on
-  CUDA or CPU.  On torch versions before 2.14, a few sampling operations have no
-  Metal kernel and CellBender transparently runs those on the CPU.
+  ``--cuda`` and ``--mps`` are mutually exclusive.  Note that Metal has no
+  double precision, so posterior estimation runs in float32 rather than float64,
+  at lower precision than it does on CUDA or CPU.  On torch versions before
+  2.14, a few sampling operations have no Metal kernel and CellBender
+  transparently runs those on the CPU.
 * ``--learning-rate``: The default value of 1e-4 is typically fine, but this value can be
   adjusted if problems arise during quality-control checks of the learning curve (as above).
 * ``--fpr``: A value of 0.01 is the default, and represents a fairly conservative

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -196,11 +196,13 @@ Considerations for setting parameters:
 * ``--cuda``: Include this flag.  The code is meant to be run on a GPU.
 * ``--mps``: Use this instead of ``--cuda`` on an Apple Silicon Mac, to run on the
   integrated GPU via Metal Performance Shaders.  Requires macOS 12.3 or later.
-  ``--cuda`` and ``--mps`` are mutually exclusive.  Note that Metal has no
-  double precision, so posterior estimation runs in float32 rather than float64,
-  at lower precision than it does on CUDA or CPU.  On torch versions before
-  2.14, a few sampling operations have no Metal kernel and CellBender
-  transparently runs those on the CPU.
+  ``--cuda`` and ``--mps`` are mutually exclusive.  Metal has no double
+  precision, so posterior estimation runs in float32 rather than float64.
+  Measured on a simulated dataset, this does not meaningfully change the
+  output: the ``map`` and ``cdf`` estimators give bit-identical counts, and
+  the ``mean`` estimator differs by at most 2e-6 counts, with identical
+  totals.  On torch versions before 2.14, a few sampling operations have no
+  Metal kernel and CellBender transparently runs those on the CPU.
 * ``--learning-rate``: The default value of 1e-4 is typically fine, but this value can be
   adjusted if problems arise during quality-control checks of the learning curve (as above).
 * ``--fpr``: A value of 0.01 is the default, and represents a fairly conservative

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -33,6 +33,8 @@ Proposed pipeline
 
     cellbender remove-background --cuda --input input_file.h5 --output output_file.h5
 
+   (on an Apple Silicon Mac, use ``--mps`` in place of ``--cuda``)
+
 #. Perform per-cell quality control checks, and filter out dead / dying cells,
    as appropriate for your experiment
 #. Perform all subsequent analyses using the CellBender count matrix. (It is useful
@@ -192,6 +194,12 @@ Considerations for setting parameters:
   (This kind of UMI curve can be seen in the ``web_summary.html`` output from
   ``cellranger count``.)
 * ``--cuda``: Include this flag.  The code is meant to be run on a GPU.
+* ``--mps``: Use this instead of ``--cuda`` on an Apple Silicon Mac, to run on the
+  integrated GPU via Metal Performance Shaders.  Requires macOS 12.3 or later.
+  ``--cuda`` and ``--mps`` are mutually exclusive.  Note that Metal supports
+  float32 only, so posterior estimation runs at lower precision than it does on
+  CUDA or CPU.  On torch versions before 2.14, a few sampling operations have no
+  Metal kernel and CellBender transparently runs those on the CPU.
 * ``--learning-rate``: The default value of 1e-4 is typically fine, but this value can be
   adjusted if problems arise during quality-control checks of the learning curve (as above).
 * ``--fpr``: A value of 0.01 is the default, and represents a fairly conservative

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 tables
 pandas
 pyro-ppl>=1.8.4
-torch
+torch>=2.13
 matplotlib
 anndata>=0.9
 ipython

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,14 @@ import pytest
 import scipy.sparse as sp
 import torch
 
+from cellbender.device import available_devices
 from cellbender.remove_background.data.extras.simulate import generate_sample_dirichlet_dataset
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
 
-USE_CUDA = torch.cuda.is_available()
+# Every backend usable on this machine. On CI this is just ['cpu'], on an NVIDIA
+# box ['cuda', 'cpu'], and on Apple Silicon ['mps', 'cpu']. Device-sensitive
+# tests parametrize over this so each machine exercises what it actually has.
+DEVICES = available_devices()
 
 
 def sparse_matrix_equal(mat1, mat2):

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -11,10 +11,11 @@ import pyro
 import pyro.optim as optim
 import pytest
 import torch
-from conftest import USE_CUDA
+from conftest import DEVICES
 from torch.distributions import constraints
 
 import cellbender
+from cellbender.device import seed_all
 from cellbender.remove_background.checkpoint import (
     create_workflow_hashcode,
     load_checkpoint,
@@ -32,29 +33,32 @@ from cellbender.remove_background.run import run_inference
 from cellbender.remove_background.vae.decoder import Decoder
 from cellbender.remove_background.vae.encoder import EncodeZ
 
+DEFAULT_DEVICE = DEVICES[0]
+
 
 class RandomState:
-    def __init__(self, use_cuda=False):
+    def __init__(self, device="cpu"):
         self.python = random.randint(0, 100000)
         self.numpy = np.random.randint(0, 100000, size=1).item()
         self.torch = torch.randint(low=0, high=100000, size=[1], device="cpu").item()
-        self.use_cuda = use_cuda
-        if self.use_cuda:
-            self.cuda = torch.randint(low=0, high=100000, size=[1], device="cuda").item()
+        self.device = device
+        self.device_draw = (
+            None if device == "cpu" else torch.randint(low=0, high=100000, size=[1], device=device).item()
+        )
 
     def __repr__(self):
-        if self.use_cuda:
-            return f"python {self.python}; numpy {self.numpy}; torch {self.torch}; torch_cuda {self.cuda}"
-        else:
-            return f"python {self.python}; numpy {self.numpy}; torch {self.torch}"
+        base = f"python {self.python}; numpy {self.numpy}; torch {self.torch}"
+        if self.device_draw is None:
+            return base
+        return f"{base}; torch_{self.device} {self.device_draw}"
 
 
 def test_create_workflow_hashcode():
     """Ensure workflow hashcodes are behaving as expected"""
 
-    tmp_args1 = argparse.Namespace(epochs=100, expected_cells=1000, use_cuda=True)
-    tmp_args2 = argparse.Namespace(epochs=200, expected_cells=1000, use_cuda=True)
-    tmp_args3 = argparse.Namespace(epochs=100, expected_cells=500, use_cuda=True)
+    tmp_args1 = argparse.Namespace(epochs=100, expected_cells=1000, device="cuda")
+    tmp_args2 = argparse.Namespace(epochs=200, expected_cells=1000, device="cuda")
+    tmp_args3 = argparse.Namespace(epochs=100, expected_cells=500, device="cuda")
     hashcode1 = create_workflow_hashcode(module_path=os.path.dirname(cellbender.__file__), args=tmp_args1)
     hashcode2 = create_workflow_hashcode(module_path=os.path.dirname(cellbender.__file__), args=tmp_args2)
     hashcode3 = create_workflow_hashcode(module_path=os.path.dirname(cellbender.__file__), args=tmp_args3)
@@ -66,26 +70,24 @@ def test_create_workflow_hashcode():
     assert hashcode1 == hashcode2
 
 
-def create_random_state_blank_slate(seed, use_cuda=USE_CUDA):
+def create_random_state_blank_slate(seed, device=DEFAULT_DEVICE):
     """Establish a base random state
     https://pytorch.org/docs/stable/notes/randomness.html
     """
     random.seed(seed)
     np.random.seed(seed)
-    torch.manual_seed(seed)
     pyro.util.set_rng_seed(seed)
-    if use_cuda:
-        torch.cuda.manual_seed_all(seed)
+    seed_all(seed, device)
 
 
-def perturb_random_state(n, use_cuda=USE_CUDA):
+def perturb_random_state(n, device=DEFAULT_DEVICE):
     """Perturb the base random state by drawing random numbers"""
     for _ in range(n):
         random.randint(0, 10)
         np.random.randint(0, 10, 1)
         torch.randn((1,), device="cpu")
-        if use_cuda:
-            torch.randn((1,), device="cuda")
+        if device != "cpu":
+            torch.randn((1,), device=device)
 
 
 @pytest.fixture(scope="function", params=[0, 1, 1234], ids=lambda x: f"seed{x}")
@@ -148,26 +150,22 @@ def test_that_randomstate_plus_perturb_gives_perturbedrandomstate(perturbed_rand
     assert str(prs0) == str(this_prs0)
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_save_and_load_random_state(tmpdir_factory, perturbed_random_state_dict, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_save_and_load_random_state(tmpdir_factory, perturbed_random_state_dict, device):
     """Test whether random states are being preserved correctly.
     perturbed_random_state_dict is important since it initializes the state."""
 
     # save the random states
     filebase = tmpdir_factory.mktemp("random_states").join("tmp_checkpoint")
-    save_random_state(filebase=filebase)
+    save_random_state(filebase=filebase, device=device)
 
     # see "what would have happened had we continued"
-    counterfactual = RandomState(use_cuda=cuda)
-    incorrect = RandomState(use_cuda=cuda)  # a second draw
+    counterfactual = RandomState(device=device)
+    incorrect = RandomState(device=device)  # a second draw
 
     # load the random states and check random number generators
-    load_random_state(filebase=filebase)
-    actual = RandomState(use_cuda=cuda)
+    load_random_state(filebase=filebase, device=device)
+    actual = RandomState(device=device)
 
     # check equality
     assert str(counterfactual) == str(actual)
@@ -186,10 +184,11 @@ class PyroModel(torch.nn.Module):
         self.encoder = EncodeZ(input_dim=dim, hidden_dims=[hidden_layer], output_dim=z_dim)
         self.decoder = Decoder(input_dim=z_dim, hidden_dims=[hidden_layer], output_dim=dim)
         self.z_dim = z_dim
-        self.use_cuda = torch.cuda.is_available()
         self.normal = pyro.distributions.Normal
         self.loss = []
-        # self.to(device='cuda' if self.use_cuda else 'cpu')  # CUDA not tested
+        # this standalone pyro model stays on CPU: accelerators are not tested here,
+        # but save_checkpoint reads .device so it has to be declared
+        self.device = "cpu"
 
     def model(self, x: torch.FloatTensor):
         pyro.module("decoder", self.decoder, update_module_params=True)
@@ -350,13 +349,9 @@ def test_save_and_load_pyro_checkpoint(tmpdir_factory, batch_size_n):
             assert disagreement == 0, "Guide traces disagree with and without checkpoint restart"
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
+@pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("scheduler", [False, True], ids=lambda b: "OneCycleLR" if b else "Adam")
-def test_save_and_load_cellbender_checkpoint(tmpdir_factory, cuda, scheduler):
+def test_save_and_load_cellbender_checkpoint(tmpdir_factory, device, scheduler):
     """Check and see if restarting from a checkpoint picks up in the same place
     we left off.  Use our model and dataloader.
     """
@@ -392,7 +387,7 @@ def test_save_and_load_cellbender_checkpoint(tmpdir_factory, cuda, scheduler):
     args.z_dim = 10
     args.z_hidden_dims = [50]
     args.model = "ambient"
-    args.use_cuda = cuda
+    args.device = device
     args.use_jit = False
     args.learning_rate = 1e-3
     args.training_fraction = 0.9

--- a/tests/test_dataprep.py
+++ b/tests/test_dataprep.py
@@ -3,21 +3,14 @@
 import numpy as np
 import pytest
 import scipy.sparse as sp
-import torch
-from conftest import sparse_matrix_equal
+from conftest import DEVICES, sparse_matrix_equal
 
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.sparse_utils import dense_to_sparse_op_torch
 
-USE_CUDA = torch.cuda.is_available()
 
-
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_dataloader_sorting(simulated_dataset, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_dataloader_sorting(simulated_dataset, device):
     """test dataset.py _overwrite_matrix_with_columns_from_another()"""
 
     d = simulated_dataset
@@ -27,7 +20,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
         batch_size=5,
         fraction_empties=0.0,
         shuffle=False,
-        use_cuda=cuda,
+        device=device,
     )
     sorted_data_loader = DataLoader(
         d["matrix"],
@@ -36,7 +29,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
         fraction_empties=0.0,
         shuffle=False,
         sort_by=lambda x: -1 * np.array(x.max(axis=1).todense()).squeeze(),
-        use_cuda=cuda,
+        device=device,
     )
 
     # try to shuffle and sort at the same time, and expect a failure
@@ -48,7 +41,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
             fraction_empties=0.0,
             shuffle=True,
             sort_by=lambda x: -1 * np.array(x.max(axis=1).todense()).squeeze(),
-            use_cuda=cuda,
+            device=device,
         )
 
     # this is copied from infer.BasePosterior._get_mean() which is not ideal

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,179 @@
+"""Tests for backend device selection and backend-specific helpers."""
+
+import os
+
+import pytest
+import torch
+from conftest import DEVICES
+
+from cellbender.device import (
+    MPS_FALLBACK_ENV_VAR,
+    available_devices,
+    checkpoint_map_location,
+    empty_cache,
+    float_dtype,
+    get_device_rng_state,
+    maybe_enable_mps_fallback,
+    resolve_device,
+    seed_all,
+    set_device_rng_state,
+    supports_float64,
+    torch_has_native_mps_sampling,
+)
+
+MPS_AVAILABLE = "mps" in DEVICES
+CUDA_AVAILABLE = "cuda" in DEVICES
+
+
+def test_available_devices_always_includes_cpu():
+    assert "cpu" in available_devices()
+
+
+def test_available_devices_ordered_fastest_first():
+    """CPU is the fallback, so it must come last."""
+    assert available_devices()[-1] == "cpu"
+
+
+def test_resolve_device_defaults_to_cpu():
+    assert resolve_device(use_cuda=False, use_mps=False) == "cpu"
+
+
+def test_resolve_device_rejects_both_backends():
+    with pytest.raises(ValueError, match="at most one"):
+        resolve_device(use_cuda=True, use_mps=True)
+
+
+@pytest.mark.skipif(CUDA_AVAILABLE, reason="CUDA is available on this machine")
+def test_resolve_device_raises_when_cuda_unavailable():
+    with pytest.raises(ValueError, match="CUDA is not available"):
+        resolve_device(use_cuda=True, use_mps=False)
+
+
+@pytest.mark.skipif(MPS_AVAILABLE, reason="MPS is available on this machine")
+def test_resolve_device_raises_when_mps_unavailable():
+    with pytest.raises(ValueError, match="MPS"):
+        resolve_device(use_cuda=False, use_mps=True)
+
+
+@pytest.mark.skipif(not MPS_AVAILABLE, reason="requires MPS")
+def test_resolve_device_returns_mps_when_available():
+    assert resolve_device(use_cuda=False, use_mps=True) == "mps"
+
+
+def test_maybe_enable_mps_fallback_ignores_other_commands():
+    assert maybe_enable_mps_fallback(["cellbender", "remove-background", "--cuda"]) is False
+
+
+def test_maybe_enable_mps_fallback_respects_explicit_env(monkeypatch):
+    """An operator who set the variable by hand keeps control of it."""
+    monkeypatch.setenv(MPS_FALLBACK_ENV_VAR, "0")
+    assert maybe_enable_mps_fallback(["cellbender", "remove-background", "--mps"]) is False
+    assert os.environ[MPS_FALLBACK_ENV_VAR] == "0"
+
+
+def test_maybe_enable_mps_fallback_tracks_torch_version(monkeypatch):
+    """The fallback is only needed while torch lacks Metal sampling kernels."""
+    monkeypatch.delenv(MPS_FALLBACK_ENV_VAR, raising=False)
+    enabled = maybe_enable_mps_fallback(["cellbender", "remove-background", "--mps"])
+    assert enabled is not torch_has_native_mps_sampling()
+    if enabled:
+        assert os.environ[MPS_FALLBACK_ENV_VAR] == "1"
+
+
+def test_checkpoint_map_location():
+    assert checkpoint_map_location("cuda") == "cuda:0"
+    assert checkpoint_map_location("mps") == "mps"
+    assert checkpoint_map_location("cpu") == "cpu"
+
+
+def test_supports_float64():
+    """Metal Shading Language has no double type."""
+    assert supports_float64("cpu")
+    assert supports_float64("cuda")
+    assert not supports_float64("mps")
+
+
+def test_float_dtype():
+    assert float_dtype("cpu") == torch.float64
+    assert float_dtype("cuda") == torch.float64
+    assert float_dtype("mps") == torch.float32
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_float_dtype_is_constructible_on_device(device):
+    """The dtype we advertise for a backend must actually work on it."""
+    tensor = torch.ones(3, dtype=float_dtype(device), device=device)
+    assert tensor.device.type == device
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_seed_all_is_reproducible(device):
+    seed_all(0, device)
+    first = torch.randn(5, device=device)
+    seed_all(0, device)
+    second = torch.randn(5, device=device)
+    assert torch.equal(first, second)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_device_rng_state_roundtrip(device):
+    state = get_device_rng_state(device)
+    if device == "cpu":
+        assert state is None
+        return
+    expected = torch.randn(5, device=device)
+    set_device_rng_state(device, state)
+    assert torch.equal(torch.randn(5, device=device), expected)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_empty_cache_runs(device):
+    empty_cache(device)
+
+
+@pytest.mark.skipif(not MPS_AVAILABLE, reason="requires MPS")
+def test_every_distribution_the_model_samples_works_on_mps():
+    """Guard against a regression in MPS coverage of the model's sampling sites.
+
+    The generative model and guide sample from Gamma (phi, epsilon), Beta (rho),
+    LogNormal (d_cell, d_empty), Normal (z), Bernoulli (y) and Poisson (counts).
+    All but Poisson sampling have Metal kernels as of torch 2.13.
+
+    Note that this cannot check the CPU fallback: torch reads
+    PYTORCH_ENABLE_MPS_FALLBACK when it registers the fallback kernel at import
+    time, and torch is already imported by the time this test runs.
+    """
+    import torch.distributions as dist
+
+    ones = torch.ones(5, device="mps")
+
+    assert dist.Gamma(ones * 2, ones).rsample().device.type == "mps"
+    assert dist.Beta(ones * 2, ones * 3).rsample().device.type == "mps"
+    assert dist.Dirichlet(ones).rsample().device.type == "mps"
+    assert dist.LogNormal(torch.zeros(5, device="mps"), ones).rsample().device.type == "mps"
+    assert dist.Normal(torch.zeros(5, device="mps"), ones).rsample().device.type == "mps"
+    assert dist.Bernoulli(logits=torch.zeros(5, device="mps")).sample().device.type == "mps"
+    assert dist.Poisson(ones * 3).log_prob(ones).device.type == "mps"
+
+
+@pytest.mark.skipif(not MPS_AVAILABLE, reason="requires MPS")
+@pytest.mark.skipif(
+    os.environ.get(MPS_FALLBACK_ENV_VAR) == "1",
+    reason="CPU fallback was enabled before torch was imported",
+)
+def test_poisson_sampling_on_mps_matches_torch_version():
+    """aten::poisson gained a Metal kernel after the torch 2.13 branch cut.
+
+    Below that version CellBender needs the CPU fallback, which is why
+    maybe_enable_mps_fallback exists. This pins which side of that line we are on
+    so the fallback can be dropped once the floor moves past it.
+    """
+    import torch.distributions as dist
+
+    rate = torch.ones(5, device="mps") * 3
+
+    if torch_has_native_mps_sampling():
+        assert dist.Poisson(rate).sample().device.type == "mps"
+    else:
+        with pytest.raises(NotImplementedError, match="aten::poisson"):
+            dist.Poisson(rate).sample()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 import pytest
-from conftest import USE_CUDA
+from conftest import DEVICES
 
 from cellbender.base_cli import get_populated_argparser
 from cellbender.remove_background import consts
@@ -12,12 +12,8 @@ from cellbender.remove_background.cli import CLI
 from cellbender.remove_background.downstream import anndata_from_h5
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_full_run(tmpdir_factory, h5_v3_file, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_full_run(tmpdir_factory, h5_v3_file, device):
     """Do a full run of the command line tool using a small simulated dataset"""
 
     tmp_dir = tmpdir_factory.mktemp("data")
@@ -36,8 +32,8 @@ def test_full_run(tmpdir_factory, h5_v3_file, cuda):
         "--epochs",
         "5",
     ]
-    if cuda:
-        input_args.append("--cuda")
+    if device != "cpu":
+        input_args.append(f"--{device}")
     args = get_populated_argparser().parse_args(input_args[1:])
     args = CLI.validate_args(args=args)
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,21 +1,13 @@
 """Tests for monitoring function."""
 
 import pytest
-import torch
+from conftest import DEVICES
 
 from cellbender.monitor import get_hardware_usage
 
-USE_CUDA = torch.cuda.is_available()
 
+@pytest.mark.parametrize("device", DEVICES)
+def test_get_hardware_usage(device):
+    """Check that a hardware usage snapshot can be produced for each backend."""
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_get_hardware_usage(cuda):
-    """Check and see if restarting from a checkpoint picks up in the same place
-    we left off.  Use our model and dataloader.
-    """
-
-    print(get_hardware_usage(use_cuda=cuda))
+    print(get_hardware_usage(device=device))

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 import torch
-from conftest import sparse_matrix_equal
+from conftest import DEVICES, sparse_matrix_equal
 
 from cellbender.remove_background.estimation import Mean
 from cellbender.remove_background.posterior import (
@@ -19,9 +19,6 @@ from cellbender.remove_background.posterior import (
     torch_binary_search,
 )
 from cellbender.remove_background.sparse_utils import dense_to_sparse_op_torch, log_prob_sparse_to_dense
-
-USE_CUDA = torch.cuda.is_available()
-
 
 # NOTE: issues caught
 # - have a test that actually creates a posterior
@@ -70,12 +67,8 @@ def log_prob_coo(request, log_prob_coo_base) -> Dict[str, Union[sp.coo_matrix, n
 
 @pytest.mark.parametrize("alpha", [0, 1, 2], ids=lambda a: f"alpha{a}")
 @pytest.mark.parametrize("n_chunks", [1, 2], ids=lambda n: f"{n}chunks")
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_PRq(log_prob_coo, alpha, n_chunks, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_PRq(log_prob_coo, alpha, n_chunks, device):
 
     target_tolerance = 0.001
 
@@ -118,7 +111,7 @@ def test_PRq(log_prob_coo, alpha, n_chunks, cuda):
         noise_count_posterior_coo=log_prob_coo["coo"],
         noise_offsets=log_prob_coo["offsets"],
         alpha=alpha,
-        device="cuda" if cuda else "cpu",
+        device=device,
         target_tolerance=target_tolerance,
         n_chunks=n_chunks,
     )
@@ -141,12 +134,8 @@ def test_PRq(log_prob_coo, alpha, n_chunks, cuda):
 @pytest.mark.parametrize("n_chunks", [1, 2], ids=lambda n: f"{n}chunks")
 # @pytest.mark.parametrize('per_gene', [False, True], ids=lambda n: 'per_gene' if n else 'overall')
 @pytest.mark.parametrize("per_gene", [False], ids=lambda n: "per_gene" if n else "overall")
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, device):
 
     target_tolerance = 0.5
 
@@ -168,7 +157,7 @@ def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
     mean_noise_csr = estimator.estimate_noise(
         noise_log_prob_coo=log_prob_coo["coo"],
         noise_offsets=log_prob_coo["offsets"],
-        device="cuda" if cuda else "cpu",
+        device=device,
     )
     print(f"Mean estimator removes {mean_noise_csr.sum()} counts total")
 
@@ -180,7 +169,7 @@ def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
         raw_count_csr_for_cells=count_matrix,
         n_cells=n_cells,
         index_converter=index_converter,
-        device="cuda" if cuda else "cpu",
+        device=device,
         per_gene=per_gene,
     )
     targets = target_fun(fpr)
@@ -195,7 +184,7 @@ def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
         raw_count_matrix=count_matrix,
         fpr=fpr,
         per_gene=per_gene,
-        device="cuda" if cuda else "cpu",
+        device=device,
         target_tolerance=target_tolerance,
         n_chunks=n_chunks,
     )
@@ -316,17 +305,12 @@ def test_torch_binary_search():
 
 @pytest.mark.parametrize("fpr", [0.0, 0.1, 0.5, 0.75, 1], ids=lambda a: f"fpr{a}")
 @pytest.mark.parametrize("per_gene", [False], ids=lambda n: "per_gene" if n else "overall")
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_compute_mean_target_removal_as_function(log_prob_coo, fpr, per_gene, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_compute_mean_target_removal_as_function(log_prob_coo, fpr, per_gene, device):
     """The target removal computation, very important for the MCKP output"""
 
     noise_count_posterior_coo = log_prob_coo["coo"]
     noise_offsets = log_prob_coo["offsets"]
-    device = "cuda" if cuda else "cpu"
 
     print("log prob posterior coo")
     print(noise_count_posterior_coo)

--- a/tests/test_sparse_utils.py
+++ b/tests/test_sparse_utils.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 import scipy.sparse as sp
-import torch
-from conftest import sparse_matrix_equal
+from conftest import DEVICES, sparse_matrix_equal
 
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.sparse_utils import (
@@ -12,8 +11,6 @@ from cellbender.remove_background.sparse_utils import (
     overwrite_matrix_with_columns_from_another,
     todense_fill,
 )
-
-USE_CUDA = torch.cuda.is_available()
 
 
 @pytest.mark.parametrize("val", [0, 1, np.nan, np.inf, -np.inf])
@@ -39,12 +36,8 @@ def test_todense_fill(val):
     np.testing.assert_array_equal(brute_force, dense)
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_dense_to_sparse_op_torch(simulated_dataset, cuda):
+@pytest.mark.parametrize("device", DEVICES)
+def test_dense_to_sparse_op_torch(simulated_dataset, device):
     """test infer.py BasePosterior.dense_to_sparse_op_torch()"""
 
     d = simulated_dataset
@@ -54,7 +47,7 @@ def test_dense_to_sparse_op_torch(simulated_dataset, cuda):
         batch_size=5,
         fraction_empties=0.0,
         shuffle=False,
-        use_cuda=cuda,
+        device=device,
     )
 
     barcodes = []

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -5,7 +5,7 @@ import pyro.infer.trace_elbo
 import pytest
 import scipy.sparse as sp
 import torch
-from conftest import USE_CUDA
+from conftest import DEVICES
 from pyro.infer.svi import SVI
 
 from cellbender.remove_background.data.dataprep import prep_sparse_data_for_training as prep_data_for_training
@@ -13,19 +13,14 @@ from cellbender.remove_background.run import get_optimizer
 from cellbender.remove_background.train import train_epoch
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
+@pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("dropped_minibatch", [False, True], ids=["", "dropped_minibatch"])
-def test_one_cycle_scheduler(dropped_minibatch, cuda):
+def test_one_cycle_scheduler(dropped_minibatch, device):
 
     # if there is a minibatch so small that it's below consts.SMALLEST_ALLOWED_BATCH
     # then the minibatch gets skipped. make sure this works with the scheduler.
 
     pyro.clear_param_store()
-    device = "cuda" if cuda else "cpu"
 
     n_cells = 3580
     n_empties = 50000
@@ -47,7 +42,7 @@ def test_one_cycle_scheduler(dropped_minibatch, cuda):
         training_fraction=1.0,
         fraction_empties=0.3,
         shuffle=True,
-        use_cuda=cuda,
+        device=device,
     )
 
     print(f"epochs = {epochs}")


### PR DESCRIPTION
Adds a `--mps` flag so CellBender can run on the integrated GPU of Apple Silicon Macs, and generalizes device handling so CUDA, MPS and CPU are treated uniformly.

This supersedes #429, which targeted the 0.3.2 code line and predates the refactor in #446. That PR is rebuilt here on current `main`, without the scratch files it carried at the repo root, and with the parts it did not cover: `checkpoint.py`, `monitor.py`, `estimation.py`, and tests.

## Device handling

- New `cellbender/device.py` collects everything that differs between backends: device resolution and validation, RNG seeding, RNG state save/restore, cache clearing, checkpoint `map_location`, and the widest float dtype a backend supports.
- The internal `use_cuda: bool` parameter becomes `device: str` across the model, dataloaders, posterior, trainer, monitor and simulation helpers.
- CLI surface is unchanged apart from the new flag. `--cuda` and `--mps` are in a mutually exclusive group, and CUDA keeps priority in the "you forgot the flag" warning.
- `pyro.plate(use_cuda=...)` is dropped in favour of the `device=` argument it was already being given.

## The two Metal limitations, and how each is handled

**No double precision.** MPS supports float32, float16, bfloat16 and complex64, but Metal Shading Language has no `double`, so a float64 tensor is rejected at construction:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64.
```

This is not a missing kernel, so `PYTORCH_ENABLE_MPS_FALLBACK` does not work around it. `todense_fill` produces float64, so every densified log-prob chunk hit this. Those chunks and the posterior regularization targets are now built at the widest dtype the backend supports, which is float32 on MPS and float64 everywhere else. I measured this rather than leaving it as a warning. Same posterior (COO 4,500,000 x 20, 504,842 nonzeros, from a 30-epoch run on simulated data), estimators re-run under three conditions:

| estimator | cpu float32 vs cpu float64 | mps float32 vs cpu float64 |
|---|---|---|
| `MAP` | 0 / 19,130 entries differ | 0 / 19,130 entries differ |
| `ThresholdCDF(q=0.5)` | 0 / 26,515 entries differ | 0 / 26,515 entries differ |
| `Mean` | max abs delta 1.9e-06 | max abs delta 1.9e-06 |

Total noise counts identical in every case. `MAP` and `ThresholdCDF` reduce through argmax and a CDF threshold, which are insensitive to perturbations that small. `Mean` is the only one affected, and its result is stored as float32 by `_estimation_array_to_csr` regardless of backend, so some of that precision was already being discarded on CUDA. The default estimator, `mckp`, computes its internal MAP with `device="cpu"` hard-coded, so it does not depend on the backend dtype at all.

So there is no startup warning; the documentation states the measured effect.

(The "float32 only" phrasing this PR originally used was wrong, and was corrected in 530d01a: float16, bfloat16 and complex64 work on MPS too. Caught by @Skylion007 on the same wording in pytorch/pytorch#193545.)

**`aten::poisson` has no Metal kernel before torch 2.14.** `PYTORCH_ENABLE_MPS_FALLBACK=1` is therefore set for `--mps` runs on older torch. It only takes effect if set before torch is first imported (setting it afterwards is silently ineffective), hence the check in `base_cli.main()` before `generate_cli_dictionary()`. The installed torch version is read via `importlib.metadata`, which does not import torch, so the fallback switches itself off once the native kernels are present, without needing a new CellBender release.

For the record, on torch 2.13.0 / macOS 26.6.1 / M4 Max:

| op | 2.10 | 2.13 |
|---|---|---|
| `aten::_standard_gamma` (Gamma: `phi`, `epsilon`) | not implemented | native |
| `aten::_sample_dirichlet` (Beta: `rho`; Dirichlet) | not implemented | native |
| `aten::poisson` | not implemented | not implemented |
| float64 | unsupported | unsupported |

`aten::poisson` and `aten::binomial` have since landed upstream (pytorch/pytorch commits `0ccbed0c38f` and `cd165c721ad`), after the 2.13 branch cut, so they will be native from 2.14.

## Two bugs fixed along the way

- Posterior regularization passed `device="cuda"` unconditionally, so `--posterior-regularization PRmu` / `PRmu_gene` failed on a CPU-only run. It now uses the selected device.
- `load_random_state` opened the accelerator RNG state file unconditionally, so resuming a checkpoint written on a machine without an accelerator raised `FileNotFoundError` on a machine that has one. The file is now optional.

## Testing

Device-sensitive tests parametrize over `available_devices()` instead of a `cuda`/`cpu` boolean, so each machine exercises the backends it actually has: `['cpu']` on CI, `['cuda', 'cpu']` on an NVIDIA box, `['mps', 'cpu']` on Apple Silicon. This is what surfaced the float64 sites above, which the CUDA-only parametrization never reached.

`tests/test_device.py` is new and covers device resolution, the fallback decision, dtype policy, RNG state round-trips, and pins which torch versions need the Poisson CPU fallback so the shim can be removed cleanly when the floor moves.

## Dependency change

`torch` becomes `torch>=2.13`. Not cosmetic: 2.13 is the first release with Metal kernels for the Gamma and Beta sampling the model does on every step, so on 2.12 and earlier the MPS training loop would bounce to CPU each iteration.

## Verification

macOS 26.6.1, Apple M4 Max, Python 3.12.14, torch 2.13.0, pyro 1.9.1:

- `ruff check`, `ruff format --check`, `mypy cellbender tests`: clean
- `pytest tests/` excluding `test_integration.py`: 244 passed, 21 skipped
- end-to-end `remove-background` on `--mps`: completes, output matches the posterior object, no negative counts

`test_integration.py` fails on its final assertion (HTML report not created) on **both** `cpu` and `mps`, and fails identically on unmodified `main`. That is #457 and is not touched here.

## Not in scope

A unified `--device {auto,cpu,cuda,mps}` flag. Happy to follow up if maintainers prefer that surface, but it would deprecate `--cuda` and touch the WDL, docs and tutorial, so it seemed better kept separate.

