### PR TITLE
Fix HTML report generation by running nbconvert in the right interpreter

### DIFF
--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -1,12 +1,14 @@
 """Functions for creation of an HTML report that plots and explains output."""
 
 import datetime
+import json
 import logging
 import os
 import shutil
 import subprocess
+import sys
 import warnings
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -36,24 +38,102 @@ os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
 warnings.filterwarnings("ignore", message="The dtype argument is deprecated and will be removed in late 2024.")
 
 
-def run_notebook_str(file):
-    return f"jupyter nbconvert --ExecutePreprocessor.timeout={TIMEOUT} --to notebook --allow-errors --execute {file}"
+def run_notebook_cmd(file: str, output: str) -> List[str]:
+    """Command that executes the report notebook, writing an executed notebook.
+
+    nbconvert is invoked as a module of the interpreter that is running
+    CellBender, not as the ``jupyter`` executable found on PATH. Those are not
+    always the same environment (a virtualenv whose bin directory is not on
+    PATH is enough to separate them), and the kernel nbconvert starts follows
+    the interpreter it was launched from. Running the wrong one means the
+    notebook cannot import cellbender.
+    """
+    return [
+        sys.executable,
+        "-m",
+        "nbconvert",
+        f"--ExecutePreprocessor.timeout={TIMEOUT}",
+        "--to",
+        "notebook",
+        "--allow-errors",
+        "--execute",
+        file,
+        "--output",
+        output,
+    ]
 
 
-def to_html_str(file, output):
-    return f"jupyter nbconvert --to html --TemplateExporter.exclude_input=True {file}"
+def to_html_cmd(file: str, output: str) -> List[str]:
+    """Command that converts an executed notebook to HTML."""
+    return [
+        sys.executable,
+        "-m",
+        "nbconvert",
+        "--to",
+        "html",
+        "--TemplateExporter.exclude_input=True",
+        file,
+        "--output",
+        output,
+    ]
+
+
+def _run_nbconvert(cmd: List[str], step: str) -> None:
+    """Run an nbconvert command, surfacing its output if it fails.
+
+    Failures used to be swallowed: the commands ran under `shell=True` without
+    `check`, so a broken environment produced a missing file much later instead
+    of an error here.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"nbconvert failed while {step} (exit code {result.returncode}).\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"stderr:\n{result.stderr.strip()}"
+        )
+
+
+def _log_notebook_cell_errors(file: str) -> None:
+    """Warn about cells that raised, since --allow-errors lets them through."""
+    try:
+        with open(file, mode="r", encoding="utf8") as f:
+            notebook = json.load(f)
+    except (OSError, ValueError):
+        return
+
+    errors = [
+        output.get("ename", "error")
+        for cell in notebook.get("cells", [])
+        for output in cell.get("outputs", [])
+        if output.get("output_type") == "error"
+    ]
+    if errors:
+        logger.warning(
+            f"The report notebook raised {len(errors)} error(s) during execution "
+            f"({', '.join(sorted(set(errors)))}). The report was still written, but "
+            f"parts of it may be missing."
+        )
 
 
 def _run_notebook(file):
     shutil.copy(file, "tmp.report.ipynb")
-    subprocess.run(run_notebook_str(file="tmp.report.ipynb"), shell=True)
+    executed = "tmp.report.nbconvert.ipynb"
+    _run_nbconvert(run_notebook_cmd(file="tmp.report.ipynb", output=executed), step="executing the report notebook")
     os.remove("tmp.report.ipynb")
-    return "tmp.report.nbconvert.ipynb"
+    _log_notebook_cell_errors(executed)
+    return executed
 
 
 def _to_html(file, output) -> str:
-    subprocess.run(to_html_str(file=file, output=output), shell=True)
-    shutil.move(file.replace(".ipynb", ".html"), output)
+    # nbconvert writes relative to the notebook unless told otherwise, so give
+    # it the directory and basename separately and let it name the file.
+    out_dir = os.path.dirname(os.path.abspath(output))
+    out_base = os.path.basename(output)
+    _run_nbconvert(
+        to_html_cmd(file=file, output=os.path.join(out_dir, out_base)),
+        step="converting the report notebook to HTML",
+    )
     os.remove(file)
     return output
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,99 @@
+"""Tests for HTML report generation."""
+
+import json
+import logging
+import subprocess
+import sys
+
+import pytest
+
+from cellbender.remove_background.report import (
+    _log_notebook_cell_errors,
+    _run_nbconvert,
+    run_notebook_cmd,
+    to_html_cmd,
+)
+
+
+@pytest.mark.parametrize("builder", [run_notebook_cmd, to_html_cmd], ids=lambda f: f.__name__)
+def test_nbconvert_runs_in_the_current_interpreter(builder):
+    """The kernel follows the interpreter nbconvert is launched from.
+
+    Calling the `jupyter` executable found on PATH can pick a different
+    environment, whose kernel cannot import cellbender, which produced an empty
+    report rather than an error.
+    """
+    cmd = builder(file="notebook.ipynb", output="out")
+    assert cmd[:3] == [sys.executable, "-m", "nbconvert"]
+
+
+@pytest.mark.parametrize("builder", [run_notebook_cmd, to_html_cmd], ids=lambda f: f.__name__)
+def test_nbconvert_output_is_explicit(builder):
+    """Do not rely on nbconvert's implicit output naming."""
+    cmd = builder(file="notebook.ipynb", output="chosen_name")
+    assert "--output" in cmd
+    assert cmd[cmd.index("--output") + 1] == "chosen_name"
+    assert "notebook.ipynb" in cmd
+
+
+def test_nbconvert_command_is_a_list_not_a_shell_string():
+    """Passed as argv, so paths containing spaces survive."""
+    cmd = run_notebook_cmd(file="a notebook.ipynb", output="out")
+    assert "a notebook.ipynb" in cmd
+
+
+def test_run_nbconvert_raises_with_stderr_on_failure():
+    """Failures used to be swallowed and surfaced later as a missing file."""
+    with pytest.raises(RuntimeError, match="nbconvert failed while testing"):
+        _run_nbconvert([sys.executable, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"], step="testing")
+
+
+def test_run_nbconvert_error_includes_the_command_and_message():
+    try:
+        _run_nbconvert([sys.executable, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"], step="testing")
+    except RuntimeError as e:
+        assert "boom" in str(e)
+        assert "exit code 3" in str(e)
+    else:
+        pytest.fail("expected RuntimeError")
+
+
+def test_run_nbconvert_succeeds_quietly():
+    _run_nbconvert([sys.executable, "-c", "pass"], step="testing")
+
+
+def _write_notebook(path, outputs):
+    path.write_text(json.dumps({"cells": [{"cell_type": "code", "outputs": outputs}]}))
+
+
+def test_cell_errors_are_reported(tmp_path, caplog):
+    """--allow-errors keeps the report, so failed cells must at least be logged."""
+    nb = tmp_path / "executed.ipynb"
+    _write_notebook(nb, [{"output_type": "error", "ename": "ModuleNotFoundError", "evalue": "no cellbender"}])
+    with caplog.at_level(logging.WARNING, logger="cellbender"):
+        _log_notebook_cell_errors(str(nb))
+    assert "ModuleNotFoundError" in caplog.text
+
+
+def test_no_warning_for_a_clean_notebook(tmp_path, caplog):
+    nb = tmp_path / "executed.ipynb"
+    _write_notebook(nb, [{"output_type": "stream", "text": "fine"}])
+    with caplog.at_level(logging.WARNING, logger="cellbender"):
+        _log_notebook_cell_errors(str(nb))
+    assert caplog.text == ""
+
+
+def test_unreadable_notebook_does_not_raise(tmp_path):
+    """Reporting on errors must never itself break the run."""
+    _log_notebook_cell_errors(str(tmp_path / "does_not_exist.ipynb"))
+    bad = tmp_path / "bad.ipynb"
+    bad.write_text("not json")
+    _log_notebook_cell_errors(str(bad))
+
+
+def test_nbconvert_module_is_importable_in_this_interpreter():
+    """The whole fix rests on `python -m nbconvert` working for this python."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nbconvert", "--version"], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip()


### PR DESCRIPTION
Fixes #457.

## What was happening

The report was generated by shelling out to `jupyter nbconvert`, resolved through `PATH`. That is not necessarily the environment CellBender is running in. A virtualenv whose `bin` directory is not on `PATH` is enough to separate them, which is common with absolute-path invocations, wrapper scripts, and HPC module setups.

Reproduced here: the active venv contains its own `jupyter`, but from that same interpreter

```python
>>> shutil.which("jupyter")
'/opt/homebrew/bin/jupyter'
```

and that jupyter's `python3` kernelspec points at `/opt/homebrew/lib/python3.12/site-packages/ipykernel`, an interpreter with no cellbender in it. Every cell of the report then raises `ModuleNotFoundError`, `--allow-errors` lets the run continue, no HTML is ever written, and the failure surfaces later and confusingly as:

```
FileNotFoundError: [Errno 2] No such file or directory: 'tmp.report.nbconvert.html'
```

## Why it stayed hidden

- `subprocess.run(..., shell=True)` was called without `check`, so a non-zero exit was ignored and stderr was discarded.
- The HTML step relied on nbconvert's implicit output naming and then `shutil.move`d the result, so a conversion failure presented as a move error.
- `--allow-errors` is deliberate, a partial report beats none, but nothing reported that cells had failed.

## The fix

- Invoke nbconvert as `sys.executable -m nbconvert`. The kernel follows the interpreter nbconvert is launched from, so this pins it to the interpreter already running CellBender. Verified directly: a probe notebook run this way reports the venv's own `sys.executable` and imports cellbender successfully.
- Pass `--output` explicitly instead of relying on implicit naming plus a move.
- Pass argv as a list, dropping `shell=True`. Paths containing spaces now work, and the shell is out of the loop.
- Check the exit code and include the command and stderr in the raised error.
- Count cells that still failed under `--allow-errors` and log a warning naming the exception types, so a degraded report says so.

## Verification

Real run on simulated data: report written, 588 KB, 8 embedded figures, title `CellBender: out`, and no `Traceback`, `ModuleNotFoundError` or `NameError` anywhere in the HTML.

- `test_integration.py` now passes. It fails on unmodified `main`.
- Full suite: 186 passed, 70 skipped.
- `ruff check`, `ruff format --check`, `mypy cellbender tests`: clean.

`tests/test_report.py` is new and covers the parts that can be asserted without a full run: that both commands start with `sys.executable -m nbconvert`, that `--output` is explicit, that argv survives spaces, that a failing command raises with its stderr and exit code included, and that failed cells are logged while a clean notebook logs nothing.

## Note for review

This touches the same functions that #468 relocates to `summary.py`. The two overlap textually but not semantically, and either merge order resolves trivially.
