### PR TITLE
Make a fresh install work, and make CI test what users install

### DIFF
--- a/cellbender/remove_background/downstream.py
+++ b/cellbender/remove_background/downstream.py
@@ -80,7 +80,6 @@ def anndata_from_h5(file: str, analyzed_barcodes_only: bool = True) -> anndata.A
         X=X,
         obs={"barcode": d.pop("barcodes").astype(str)},
         var={"gene_name": (d.pop("gene_names") if "gene_names" in d.keys() else d.pop("name")).astype(str)},
-        dtype=X.dtype,
     )
     adata.obs.set_index("barcode", inplace=True)
     adata.var.set_index("gene_name", inplace=True)
@@ -186,12 +185,14 @@ def load_anndata_from_input(input_file: str) -> anndata.AnnData:
     # Create anndata object from dict.
     barcodes = d.pop("barcode")
     gene_names = d.pop("gene_name")
+    matrix = d.pop("matrix")
     assert isinstance(barcodes, np.ndarray) and isinstance(gene_names, np.ndarray)
+    assert isinstance(matrix, (np.ndarray, sp.spmatrix))
+    # AnnData no longer casts via a dtype argument, so cast before handing it over.
     adata = anndata.AnnData(
-        X=d.pop("matrix"),
+        X=matrix.astype(int),
         obs={"barcode": barcodes.astype(str)},
         var={"gene_name": gene_names.astype(str)},
-        dtype=int,
     )
     adata.obs.set_index("barcode", inplace=True)
     adata.var.set_index("gene_name", inplace=True)

--- a/cellbender/remove_background/report.py
+++ b/cellbender/remove_background/report.py
@@ -5,7 +5,6 @@ import logging
 import os
 import shutil
 import subprocess
-import warnings
 from typing import Any, Dict
 
 import matplotlib.pyplot as plt
@@ -30,10 +29,6 @@ TIMEOUT = 1200  # twenty minutes should always be way more than enough
 # counteract an error when I run locally
 # https://stackoverflow.com/questions/53014306/error-15-initializing-libiomp5-dylib-but-found-libiomp5-dylib-already-initial
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
-
-
-# ignore a specific dtype FutureWarning, I think from anndata
-warnings.filterwarnings("ignore", message="The dtype argument is deprecated and will be removed in late 2024.")
 
 
 def run_notebook_str(file):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ scikit-learn
 ruff==0.15.12
 mypy==1.20.2
 mypy_extensions==1.1.0
-numpy<2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ scipy
 tables
 pandas
 pyro-ppl>=1.8.4
-torch
+torch>=2.0
 matplotlib
-anndata>=0.9
+anndata>=0.10
 ipython
 ipykernel
 nbconvert


### PR DESCRIPTION
Fixes #407.

The issue says a fresh `pip install` doesn't get working versions. It doesn't, and CI cannot currently see that.

## The break

anndata removed the `dtype` argument from `AnnData.__init__` (deprecated since 0.10). A fresh install resolves anndata 0.13.2, where both call sites in `downstream.py` raise:

```
TypeError: AnnData.__init__() got an unexpected keyword argument 'dtype'
```

That takes out `anndata_from_h5`, `load_anndata_from_input_and_output`, and any full run that writes a report. In a clean venv resolving as a user would, **7 tests fail**. The same tests pass in CI.

## Why CI couldn't see it

`requirements-dev.txt` carried `numpy<2.1`. CI therefore resolved a dependency set no user gets:

| | CI | `pip install cellbender` |
|---|---|---|
| numpy | 2.0.2 | 2.5.2 |
| anndata | 0.13.2 | 0.13.2 |

The pin wasn't what saved CI here (anndata was the same in both), but it is the mechanism by which CI's environment drifted from the user's, and it was never justified: nothing in the repo needs numpy below 2.1. Removing it means CI now resolves what `pip install cellbender` resolves, so the next incompatibility of this kind fails in CI instead of in someone's terminal. That is the part of this change that prevents recurrence.

Compounding it, `report.py` explicitly silenced the exact warning that predicted this break:

```python
warnings.filterwarnings("ignore", message="The dtype argument is deprecated and will be removed in late 2024.")
```

The deprecation notice was being suppressed for the two years it was warning. That filter is gone along with the argument it was hiding.

## The fixes

- `dtype=X.dtype` was a no-op, `X` already had that dtype. Dropped.
- `dtype=int` genuinely converted, so the cast is now explicit on the matrix.
- `anndata>=0.10`. This floor is load-bearing rather than decorative: before 0.10, omitting `dtype` meant AnnData silently coerced `X` to float32, so the new code needs a version that respects `X`'s dtype.
- `torch>=2.0`, recording what has been true since #420.

## On pinning the rest

I deliberately did not add floors to numpy, scipy, tables, pandas, matplotlib or psutil. I have not installed or tested those lower bounds, and writing numbers I haven't verified would recreate exactly the problem this issue describes: constraints that state an intention rather than a tested configuration. Happy to add them if you want, but they should come with a CI job that resolves the minimum set, otherwise they are decoration.

## Verification

Two environments, both green, 173 passed / 69 skipped:

- clean venv resolving as a user would: numpy 2.5.2, anndata 0.13.2, torch 2.13.0, scipy 1.18.0, pandas 3.0.5
- the CI dependency set

`ruff check`, `ruff format --check`, `mypy cellbender tests`: clean.

`test_integration.py` is excluded from both runs because it fails for an unrelated reason on `main` (HTML report generation, #457, fixed separately in #469). With #469 applied it passes.
