### PR TITLE
Keep the noise-count axis intact when chunking the posterior

### DIFF
--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -704,7 +704,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
 
 def chunked_iterator(
     coo: sp.coo_matrix, max_dense_batch_size_GB: float = 1.0
-) -> Generator[Tuple[sp.coo_matrix, np.ndarray, np.ndarray], None, None]:
+) -> Generator[Tuple[sp.coo_matrix, np.ndarray], None, None]:
     """Return an iterator which yields the full dataset in chunks.
 
     NOTE: Idea is to prevent memory overflow. The use case is for worst-case
@@ -717,10 +717,12 @@ def chunked_iterator(
         max_dense_batch_size_GB: Size of a batch on disk, in gigabytes.
 
     Returns:
-        A generator that yields compact CSR sparse matrices until the whole dataset
-        has been yielded. "Compact" in the sense that if they are made dense, there
-        will be no all-zero rows.
-            Tuple[chunk csr, actual row values in the full matrix]
+        A generator that yields chunks until the whole dataset has been yielded.
+        Rows are compacted, in the sense that a densified chunk has no all-zero
+        rows. Columns are not: a column index of a yielded chunk is still a noise
+        count, which is what every caller relies on when it takes an argmax, a
+        cumulative sum or a probability-weighted average over that axis.
+            Tuple[chunk coo, actual row values in the full matrix]
 
     """
     n_elements_in_batch = max_dense_batch_size_GB * 1e9 / 4  # torch float32 is 4 bytes
@@ -736,12 +738,16 @@ def chunked_iterator(
         logic = coo_row_series.isin(set(row_m_values))
         # Map these row values to a compact set of unique integers
         unique_row_values, rows = np.unique(coo.row[logic], return_inverse=True)
-        unique_col_values, cols = np.unique(coo.col[logic], return_inverse=True)
+        # Columns are deliberately left alone. Compacting them onto 0..K-1 would
+        # make a column index mean "position among occupied noise counts" rather
+        # than "noise count", which every caller reads it as. The batch size
+        # above is already computed from the full column count, so keeping the
+        # axis intact stays inside the memory budget rather than exceeding it.
         chunk_coo = sp.coo_matrix(
-            (coo.data[logic], (rows, cols)),
-            shape=(len(unique_row_values), len(unique_col_values)),
+            (coo.data[logic], (rows, coo.col[logic])),
+            shape=(len(unique_row_values), coo.shape[1]),
         )
-        yield (chunk_coo, unique_row_values, unique_col_values)
+        yield (chunk_coo, unique_row_values)
 
 
 def apply_function_dense_chunks(
@@ -775,7 +781,7 @@ def apply_function_dense_chunks(
     out = np.zeros(array_length)
     a = 0
 
-    for coo, row, col in chunked_iterator(coo=noise_log_prob_coo):
+    for coo, row in chunked_iterator(coo=noise_log_prob_coo):
         dense_tensor = torch.tensor(log_prob_sparse_to_dense(coo)).to(device)
         if torch.numel(dense_tensor) == 0:
             # github issue 207

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -17,6 +17,8 @@ from cellbender.remove_background.estimation import (
     SingleSample,
     ThresholdCDF,
     _estimation_array_to_csr,
+    apply_function_dense_chunks,
+    chunked_iterator,
     pandas_grouped_apply,
 )
 from cellbender.remove_background.posterior import IndexConverter, dense_to_sparse_op_torch, log_prob_sparse_to_dense
@@ -408,3 +410,54 @@ def test_estimation_array_to_csr():
     truth_csr = coo.tocsr()
 
     assert sparse_matrix_equal(output_csr, truth_csr)
+
+
+@pytest.fixture(scope="module")
+def log_prob_coo_with_unoccupied_columns() -> Dict[str, Union[sp.coo_matrix, np.ndarray]]:
+    """A posterior whose occupied noise-count columns do not start at zero.
+
+    Every row puts its mass on c in {1, 2, 3}, with the mode at c = 2. Column 0
+    is unoccupied throughout, so a chunker that compacts the column axis shifts
+    every answer down by one.
+    """
+    n_rows = 4
+    counts = np.array([1, 2, 3])
+    probs = np.array([0.2, 0.7, 0.1])
+    rows = np.repeat(np.arange(n_rows), counts.size)
+    cols = np.tile(counts, n_rows)
+    data = np.tile(np.log(probs), n_rows)
+    return {
+        "coo": sp.coo_matrix((data, (rows, cols)), shape=(n_rows, 5)),
+        "map": np.full(n_rows, 2),  # the mode sits at c = 2
+        "mean": np.full(n_rows, float((counts * probs).sum())),
+    }
+
+
+def test_chunked_iterator_preserves_the_noise_count_axis(log_prob_coo_with_unoccupied_columns):
+    """The column index of a yielded chunk must still mean "noise count"."""
+    coo = log_prob_coo_with_unoccupied_columns["coo"]
+    for chunk, _rows in chunked_iterator(coo=coo):
+        assert chunk.shape[1] == coo.shape[1], (
+            "chunk column axis was compacted, so its indices no longer are noise counts"
+        )
+        dense = log_prob_sparse_to_dense(chunk.tocoo())
+        # the mode must stay at the real noise count, not at a compacted position
+        np.testing.assert_array_equal(dense.argmax(axis=1), log_prob_coo_with_unoccupied_columns["map"])
+
+
+def test_map_is_a_real_noise_count_when_low_counts_are_unoccupied(log_prob_coo_with_unoccupied_columns):
+    result = apply_function_dense_chunks(
+        noise_log_prob_coo=log_prob_coo_with_unoccupied_columns["coo"], fun=MAP.torch_argmax
+    )
+    np.testing.assert_array_equal(result["result"], log_prob_coo_with_unoccupied_columns["map"])
+
+
+def test_mean_is_a_real_noise_count_when_low_counts_are_unoccupied(log_prob_coo_with_unoccupied_columns):
+    def _torch_mean(x):
+        c = torch.arange(x.shape[1], dtype=x.dtype).to(x.device)
+        return torch.matmul(x.exp(), c.t())
+
+    result = apply_function_dense_chunks(
+        noise_log_prob_coo=log_prob_coo_with_unoccupied_columns["coo"], fun=_torch_mean
+    )
+    np.testing.assert_allclose(result["result"], log_prob_coo_with_unoccupied_columns["mean"], rtol=1e-6)


### PR DESCRIPTION
Fixes #460.

## The defect

`chunked_iterator` compacted a chunk's occupied noise-count columns onto `0..K-1` and returned `unique_col_values` so the mapping could be undone. Its only caller, `apply_function_dense_chunks`, bound that value as `col` and never used it.

Every consumer reads the column axis as the noise count itself:

| estimator | operation | what it returns |
|---|---|---|
| `MAP` | `x.argmax(dim=-1)` | an index |
| `SingleSample` | `Categorical(logits=x).sample()` | an index |
| `ThresholdCDF` | `(x.exp().cumsum(-1) <= q).sum(-1)` | an index |
| `Mean` | `matmul(x.exp(), arange(x.shape[1]))` | positional values |

So whenever a chunk's occupied columns were not exactly `0..K-1`, all four decoded a *position among occupied counts* as if it were a noise count.

Confirmed directly:

```python
rows = np.repeat(np.arange(4), 3)
cols = np.tile([1, 2, 3], 4)                    # column 0 unoccupied
log_probs = np.tile(np.log([0.2, 0.7, 0.1]), 4) # mode at c = 2
coo = sp.coo_matrix((log_probs, (rows, cols)), shape=(4, 5))

apply_function_dense_chunks(coo, MAP.torch_argmax)["result"]
# main:  [1. 1. 1. 1.]   <- compacted position
# true:  [2. 2. 2. 2.]
```

## The fix

The column axis is left alone rather than compacted and then remapped.

A post-hoc remap would not work for `Mean` anyway: its output is a probability-weighted average, not an index, so `unique_col_values[result]` is meaningless there. It would need the real column values *inside* the function. Removing the compaction removes the mismatch at its source instead, and all four estimators are then correct exactly as written.

This costs no memory. The batch size is `max_dense_batch_size_GB * 1e9 / 4 / coo.shape[1]`, computed from the **full** column count, so chunks were previously narrower than the budget already assumed. Keeping the axis intact respects that budget rather than exceeding it.

Since the mapping is now the identity by construction, `chunked_iterator` yields a 2-tuple and the docstring says explicitly that a column index is a noise count.

## How alarming is this, honestly

Less than it first appears, and I would rather say so than oversell it.

The noise-count offsets give each row a contiguous run of columns starting at 0, so the union across the many rows of a chunk is contiguous in practice. Measured on a real posterior from a 30-epoch run (COO `4,500,000 x 20`, 482,594 nonzeros): columns `0..19`, no gaps, mapping was the identity. A full run before and after this change produces identical results.

So this is a **latent** defect, not one currently corrupting anyone's output. It is still worth removing: nothing in the code enforces the property the correctness depends on, the invariant is nowhere stated, and the failure mode is silent wrong counts rather than an error.

## Verification

- 3 new regression tests in `test_estimation.py` covering a posterior whose mass sits at `c ∈ {1,2,3}` with column 0 unoccupied. On `main`: `MAP` returns 1 instead of 2, `Mean` returns 0.9 instead of 1.9.
- `test_estimation.py`: 75 passed. Full suite: 176 passed, 69 skipped.
- `ruff check`, `ruff format --check`, `mypy cellbender tests`: clean.
- End-to-end run on simulated data completes, chunk covers the full 20-column axis, results unchanged.

`test_integration.py` is excluded from the suite figure: it fails on `main` for an unrelated reason (#457, fixed in #469).
