### PR TITLE
Do not divide by psutil.cpu_count() without checking it

### DIFF
--- a/cellbender/monitor.py
+++ b/cellbender/monitor.py
@@ -37,9 +37,12 @@ def get_hardware_usage(use_cuda: bool) -> str:
     else:
         gpu_string = ""
 
+    # psutil.cpu_count() returns None when it cannot determine a count, which
+    # would make this raise TypeError in the middle of a debug log line.
+    n_cpus = psutil.cpu_count() or 1
     cpu_string = (
         f"Avg CPU load over past minute: "
-        f"{psutil.getloadavg()[0] / psutil.cpu_count() * 100:.1f} %\n"
+        f"{psutil.getloadavg()[0] / n_cpus * 100:.1f} %\n"
         f"RAM in use: {bytes2human(mem.used)} ({mem.percent} %)"
     )
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,3 +19,9 @@ def test_get_hardware_usage(cuda):
     """
 
     print(get_hardware_usage(use_cuda=cuda))
+
+
+def test_hardware_usage_survives_unknown_cpu_count(monkeypatch):
+    """psutil.cpu_count() returns None when it cannot determine a count."""
+    monkeypatch.setattr("cellbender.monitor.psutil.cpu_count", lambda *a, **k: None)
+    assert "Avg CPU load" in get_hardware_usage(use_cuda=False)


### PR DESCRIPTION
A small latent crash noticed while changing this function for #467, kept separate because it has nothing to do with device handling.

`psutil.cpu_count()` returns `None` when it cannot determine a count. [monitor.py:42](https://github.com/broadinstitute/CellBender/blob/main/cellbender/monitor.py#L42) divides by it unguarded, so on such a machine a run started with `--debug` dies mid-training with:

```
TypeError: unsupported operand type(s) for /: 'float' and 'NoneType'
```

Falls back to 1. Narrow, but it only bites in `--debug`, which is exactly when someone is already trying to diagnose something else.

A regression test monkeypatches `cpu_count` to return `None`. It reproduces the `TypeError` on `main` and passes with the fix.

`ruff check`, `ruff format --check`, `mypy cellbender tests` clean.