### PR TITLE
Stop mckp from silently swallowing the requested device

### DIFF
--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -428,6 +428,7 @@ class MultipleChoiceKnapsack(EstimationMethod):
         verbose: bool = False,
         n_chunks: Optional[int] = None,
         use_multiple_processes: bool = False,
+        device: str = "cpu",
         **kwargs,
     ) -> sp.csr_matrix:
         """Given the full probabilistic posterior, compute noise counts
@@ -442,6 +443,9 @@ class MultipleChoiceKnapsack(EstimationMethod):
                 If None, targets about 5000 genes per chunk.
             use_multiple_processes: True to use multiprocessing. Seems faster
                 without using it, not entirely clear why
+            device: The backend the caller selected. Accepted so that requesting
+                an accelerator is not silently swallowed, but this estimator
+                computes its MAP step on the CPU regardless, to bound memory use.
 
         Returns:
             noise_count_csr: Estimated noise count matrix.
@@ -456,6 +460,11 @@ class MultipleChoiceKnapsack(EstimationMethod):
         )
 
         t0 = time.time()
+
+        if device != "cpu":
+            logger.debug(
+                f"Estimator 'mckp' computes its MAP step on the CPU rather than on {device}, to bound memory use."
+            )
 
         if use_multiple_processes:
             logger.info("Dividing dataset into chunks of genes")
@@ -579,6 +588,9 @@ class MultipleChoiceKnapsack(EstimationMethod):
 
         # First we need to compute the MAP to find out which direction to go.
         t = time.time()
+        # Deliberately on the CPU even when an accelerator was requested: MCKP
+        # is the memory-hungry estimator (issue #396) and this MAP runs over a
+        # whole chunk at once. estimate_noise() tells the user about it.
         map_dict = apply_function_dense_chunks(
             noise_log_prob_coo=noise_log_prob_coo, fun=MAP.torch_argmax, device="cpu"
         )

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -408,3 +408,24 @@ def test_estimation_array_to_csr():
     truth_csr = coo.tocsr()
 
     assert sparse_matrix_equal(output_csr, truth_csr)
+
+
+def test_mckp_accepts_a_device_without_silently_ignoring_it(log_prob_coo, caplog):
+    """--cuda / --mps must not be swallowed without a word.
+
+    MCKP computes its MAP step on the CPU deliberately, to bound memory use
+    (issue #396). That is fine, but it used to absorb the caller's device into
+    **kwargs and say nothing, so the flag looked effective and was not.
+    """
+    import logging
+
+    converter = IndexConverter(total_n_cells=3, total_n_genes=5)
+    estimator = MultipleChoiceKnapsack(index_converter=converter)
+    with caplog.at_level(logging.DEBUG, logger="cellbender"):
+        estimator.estimate_noise(
+            noise_log_prob_coo=log_prob_coo["coo"],
+            noise_offsets=log_prob_coo["offsets"],
+            noise_targets_per_gene=np.array([1, 0, 0, 0, 0]),
+            device="cuda",
+        )
+    assert "mckp" in caplog.text and "CPU" in caplog.text


### PR DESCRIPTION
Noticed while measuring the effect of device selection on estimation for #467.

`MultipleChoiceKnapsack.estimate_noise` has no `device` parameter. `run.py` passes `device=args.device` to every estimator, so for mckp it lands in `**kwargs` and is dropped. mckp is the **default** estimator, which means `--cuda` (and `--mps`) appear to apply to it and do not.

## What this PR does not do

It does not move the computation. The hard-coded CPU is deliberate: it predates the 2026 refactor, and mckp is the memory-hungry estimator whose MAP step runs over a whole chunk at once, which is what #396 (`OutOfMemory error when computing target noise counts per gene`) is about. Flipping that to GPU is a memory trade-off you should make deliberately, and I cannot validate it against the datasets that hit #396.

## What it does

Makes the choice visible instead of invisible:

- `device` is accepted and documented on the signature, rather than silently absorbed.
- A debug line states that the MAP step runs on the CPU rather than the requested device, and why.
- The two hard-coded `device="cpu"` call sites carry a comment explaining the intent, so the next reader does not take them for an oversight, as I initially did.

## Worth your decision

Should mckp honour `--cuda` for that MAP step? There is a real speed-up available, at a memory cost that #396 suggests is not free. Happy to implement whichever way you want, including a flag to opt in.

## Verification

Full suite 176 passed, 69 skipped. `ruff check`, `ruff format --check`, `mypy cellbender tests` clean. New test asserts that a caller passing `device="cuda"` gets told, rather than silence.