### PR TITLE
Add MPS backend support for Apple silicon

### DIFF
--- a/cellbender/monitor.py
+++ b/cellbender/monitor.py
@@ -12,12 +12,25 @@ import torch
 from psutil._common import bytes2human
 
 
-def get_hardware_usage(use_cuda: bool) -> str:
+def empty_cache(device: str) -> None:
+    """Free cached accelerator memory, for backends that cache allocations."""
+
+    if device.startswith("cuda"):
+        torch.cuda.empty_cache()
+    elif device.startswith("mps"):
+        torch.mps.empty_cache()
+
+
+def get_hardware_usage(device: str) -> str:
     """Get a current snapshot of RAM, CPU, GPU memory, and GPU utilization as a string"""
 
     mem = psutil.virtual_memory()
 
-    if use_cuda:
+    if device.startswith("mps"):
+        # No utilization counter is exposed for the Apple silicon GPU, and its
+        # memory is shared with the RAM figure reported below.
+        gpu_string = f"GPU memory allocated: {torch.mps.current_allocated_memory() / 1e9} GB\n"
+    elif device.startswith("cuda"):
         # Run nvidia-smi to get GPU utilization
         gpu_query = "utilization.gpu"
         format = "csv,nounits,noheader"

--- a/cellbender/remove_background/argparser.py
+++ b/cellbender/remove_background/argparser.py
@@ -56,6 +56,13 @@ def add_subparser_args(subparsers: argparse._SubParsersAction) -> argparse._SubP
         help="Including the flag --cuda will run the inference on a GPU.",
     )
     subparser.add_argument(
+        "--mps",
+        dest="use_mps",
+        action="store_true",
+        help="Including the flag --mps will run the inference on the GPU of an Apple "
+        "silicon Mac, see https://pytorch.org/docs/stable/notes/mps.html",
+    )
+    subparser.add_argument(
         "--checkpoint",
         nargs=None,
         type=str,

--- a/cellbender/remove_background/checkpoint.py
+++ b/cellbender/remove_background/checkpoint.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     USE_PYRO = False
 USE_CUDA = torch.cuda.is_available()
+USE_MPS = torch.backends.mps.is_available()
 
 
 def save_random_state(filebase: str) -> List[str]:
@@ -62,6 +63,8 @@ def save_random_state(filebase: str) -> List[str]:
     if USE_CUDA:
         cuda_random_state = torch.cuda.get_rng_state_all()
         file_dict.update({filebase + "_random.cuda": cuda_random_state})
+    if USE_MPS:
+        file_dict.update({filebase + "_random.mps": torch.mps.get_rng_state()})
 
     # Save it
     for file, state in file_dict.items():
@@ -96,6 +99,11 @@ def load_random_state(filebase: str):
         with open(filebase + "_random.cuda", "rb") as f:
             cuda_random_state = pickle.load(f)
         torch.cuda.set_rng_state_all(cuda_random_state)
+
+    if USE_MPS:
+        with open(filebase + "_random.mps", "rb") as f:
+            mps_random_state = pickle.load(f)
+        torch.mps.set_rng_state(mps_random_state)
 
 
 def save_checkpoint(

--- a/cellbender/remove_background/cli.py
+++ b/cellbender/remove_background/cli.py
@@ -75,15 +75,30 @@ class CLI(AbstractCLI):
         assert args.training_fraction > 0, "training-fraction must be > 0"
         assert args.training_fraction <= 1.0, "training-fraction must be <= 1"
 
-        # If cuda is requested, make sure it is available.
+        # Resolve the compute backend. CUDA takes precedence over MPS.
+        args.device = "cpu"
         if args.use_cuda:
             assert torch.cuda.is_available(), "Trying to use CUDA, but CUDA is not available."
+            args.device = "cuda"
+        elif args.use_mps:
+            if not torch.backends.mps.is_built():
+                raise AssertionError("Trying to use MPS, but this PyTorch install was not built with MPS enabled.")
+            if not torch.backends.mps.is_available():
+                raise AssertionError("Trying to use MPS, but no MPS-enabled device is available on this machine.")
+            args.device = "mps"
         else:
-            # Warn the user in case the CUDA flag was forgotten by mistake.
+            # Warn the user in case the accelerator flag was forgotten by mistake.
             if torch.cuda.is_available():
                 sys.stdout.write(
                     "Warning: CUDA is available, but will not be "
                     "used.  Use the flag --cuda for "
+                    "significant speed-ups.\n\n"
+                )
+                sys.stdout.flush()  # Write immediately
+            elif torch.backends.mps.is_available():
+                sys.stdout.write(
+                    "Warning: an Apple silicon GPU is available, but will not "
+                    "be used.  Use the flag --mps for "
                     "significant speed-ups.\n\n"
                 )
                 sys.stdout.flush()  # Write immediately

--- a/cellbender/remove_background/data/dataprep.py
+++ b/cellbender/remove_background/data/dataprep.py
@@ -59,7 +59,7 @@ class DataLoader:
                  fraction_empties: float = consts.FRACTION_EMPTIES,
                  shuffle: bool = True,
                  sort_by: Optional[Callable[[sp.csr_matrix], np.ndarray]] = None,
-                 use_cuda: bool = True):
+                 device: str = 'cpu'):
         """
         Args:
             dataset: Droplet count matrix [cell, gene]
@@ -73,7 +73,8 @@ class DataLoader:
                 the dataset. Dataloader will load data in order of increasing
                 values. Object attributes sort_order and unsort_order will be
                 made available.
-            use_cuda: True to load data to GPU
+            device: Backend on which to place the minibatches, one of
+                ['cpu', 'cuda', 'mps']
         """
         if shuffle:
             assert sort_by is None, 'Cannot sort_by and shuffle at the same time'
@@ -98,10 +99,7 @@ class DataLoader:
         self.fraction_empties = fraction_empties
         self.cell_batch_size = int(batch_size * (1. - fraction_empties))
         self.shuffle = shuffle
-        self.device = 'cpu'
-        self.use_cuda = use_cuda
-        if self.use_cuda:
-            self.device = 'cuda'
+        self.device = device
         self._length = None
         self._reset()
 
@@ -199,7 +197,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
                                   fraction_empties: float = consts.FRACTION_EMPTIES,
                                   batch_size: int = consts.DEFAULT_BATCH_SIZE,
                                   shuffle: bool = True,
-                                  use_cuda: bool = True) -> Tuple[
+                                  device: str = 'cpu') -> Tuple[
                                       "DataLoader",
                                       "DataLoader"]:
     """Create torch.utils.data.DataLoaders for train and tests set.
@@ -222,7 +220,8 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
         batch_size: Number of cell barcodes per mini-batch of data.
         shuffle: Passed as an argument to torch.utils.data.DataLoader.  If
             True, the data is reshuffled at every epoch.
-        use_cuda: If True, the data loader will load tensors on GPU.
+        device: Backend on which the data loader places tensors, one of
+            ['cpu', 'cuda', 'mps'].
 
     Returns:
         train_loader: torch.utils.data.DataLoader object for training set.
@@ -257,7 +256,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
                               batch_size=batch_size,
                               fraction_empties=fraction_empties,
                               shuffle=shuffle,
-                              use_cuda=use_cuda)
+                              device=device)
 
     # Set up test dataloader.
     test_dataset = dataset[test_indices, ...]
@@ -267,7 +266,7 @@ def prep_sparse_data_for_training(dataset: sp.csr_matrix,
                              batch_size=batch_size,
                              fraction_empties=fraction_empties,
                              shuffle=shuffle,
-                             use_cuda=use_cuda)
+                             device=device)
 
     return train_loader, test_loader
 

--- a/cellbender/remove_background/data/dataset.py
+++ b/cellbender/remove_background/data/dataset.py
@@ -452,7 +452,7 @@ class SingleCellRNACountsDataset:
         return trimmed_matrix
 
     def get_dataloader(self,
-                       use_cuda: bool = True,
+                       device: str = 'cpu',
                        batch_size: int = 200,
                        shuffle: bool = False,
                        analyzed_bcs_only: bool = True,
@@ -461,7 +461,7 @@ class SingleCellRNACountsDataset:
         """Return a dataloader for the count matrix.
 
         Args:
-            use_cuda: Whether to load data into GPU memory.
+            device: Backend on which to place the data, one of ['cpu', 'cuda', 'mps'].
             batch_size: Size of minibatch of data yielded by dataloader.
             shuffle: Whether dataloader should shuffle the data.
             analyzed_bcs_only: Only include the barcodes that have been
@@ -488,7 +488,7 @@ class SingleCellRNACountsDataset:
             fraction_empties=0.,
             shuffle=shuffle,
             sort_by=sort_by,
-            use_cuda=use_cuda,
+            device=device,
         )
         return data_loader
 

--- a/cellbender/remove_background/data/extras/simulate.py
+++ b/cellbender/remove_background/data/extras/simulate.py
@@ -82,16 +82,8 @@ def generate_sample_inferred_model_dataset(
 
     # Find z values for cells.
     data_loader = ckpt['train_loader']
-    if torch.cuda.is_available():
-        data_loader.use_cuda = True
-        data_loader.device = 'cuda'
-        model.use_cuda = True
-        model.device = 'cuda'
-    else:
-        data_loader.use_cuda = False
-        data_loader.device = 'cpu'
-        model.use_cuda = False
-        model.device = 'cpu'
+    data_loader.device = DEVICE
+    model.device = DEVICE
     z = np.zeros((len(data_loader), model.encoder['z'].output_dim))
     p = np.zeros(len(data_loader))
     chi_ambient = pyro.param('chi_ambient').detach()

--- a/cellbender/remove_background/estimation.py
+++ b/cellbender/remove_background/estimation.py
@@ -17,7 +17,7 @@ import scipy.sparse as sp
 import torch
 from torch.distributions.categorical import Categorical
 
-from cellbender.remove_background.sparse_utils import log_prob_sparse_to_dense
+from cellbender.remove_background.sparse_utils import log_prob_sparse_to_dense, tensor_to_device
 
 logger = logging.getLogger("cellbender")
 
@@ -134,7 +134,7 @@ class Mean(EstimationMethod):
         # c = torch.arange(noise_log_prob_coo.shape[1], dtype=float).to(device).t()
 
         def _torch_mean(x):
-            c = torch.arange(x.shape[1], dtype=float).to(x.device)
+            c = torch.arange(x.shape[1], dtype=x.dtype).to(x.device)
             return torch.matmul(x.exp(), c.t())
 
         result = apply_function_dense_chunks(noise_log_prob_coo=noise_log_prob_coo, fun=_torch_mean, device=device)
@@ -776,7 +776,7 @@ def apply_function_dense_chunks(
     a = 0
 
     for coo, row, col in chunked_iterator(coo=noise_log_prob_coo):
-        dense_tensor = torch.tensor(log_prob_sparse_to_dense(coo)).to(device)
+        dense_tensor = tensor_to_device(log_prob_sparse_to_dense(coo), device)
         if torch.numel(dense_tensor) == 0:
             # github issue 207
             continue

--- a/cellbender/remove_background/model.py
+++ b/cellbender/remove_background/model.py
@@ -94,7 +94,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         encoder: An instance of an encoder object.  Can be a CompositeEncoder.
         decoder: An instance of a decoder object.
         dataset_obj_priors: Dict which contains relevant priors.
-        use_cuda: Will use GPU if True.
+        device: Backend to place the model on, one of ['cpu', 'cuda', 'mps'].
         analyzed_gene_names: Here only so that when we save a checkpoint, if we
             ever want to look at it, we will know which genes are which.
         phi_loc_prior: Mean of gamma distribution for global overdispersion.
@@ -106,7 +106,6 @@ class RemoveBackgroundPyroModel(nn.Module):
 
     Attributes:
         All the above, plus
-        device: Either 'cpu' or 'cuda' depending on value of use_cuda.
         loss: Dict that records information about the loss during training.
 
     """
@@ -122,7 +121,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         analyzed_gene_names: np.ndarray,
         empty_UMI_threshold: int,
         log_counts_crossover: float,
-        use_cuda: bool,
+        device: str,
         phi_loc_prior: float = consts.PHI_LOC_PRIOR,
         phi_scale_prior: float = consts.PHI_SCALE_PRIOR,
         rho_alpha_prior: float = consts.RHO_ALPHA_PRIOR,
@@ -156,20 +155,16 @@ class RemoveBackgroundPyroModel(nn.Module):
         self.log_counts_crossover = log_counts_crossover
         self.counts_crossover = np.exp(log_counts_crossover)
 
-        # Determine whether we are working on a GPU.
-        if use_cuda:
-            # Calling cuda() here will put all the parameters of
-            # the encoder and decoder networks into GPU memory.
-            self.cuda()
+        # Move the model onto the requested backend. This puts all the
+        # parameters of the encoder and decoder networks into its memory.
+        if device != "cpu":
+            self.to(device)
             try:
                 for key, value in self.encoder.items():
-                    value.cuda()
+                    value.to(device)
             except KeyError:
                 pass
-            self.device = "cuda"
-        else:
-            self.device = "cpu"
-        self.use_cuda = use_cuda
+        self.device = device
 
         # Priors
         assert dataset_obj_priors["d_std"] > 0, (
@@ -257,7 +252,7 @@ class RemoveBackgroundPyroModel(nn.Module):
             phi = pyro.sample("phi", dist.Gamma(self.phi_conc_prior, self.phi_rate_prior))
 
         # Happens in parallel for each data point (cell barcode) independently:
-        with pyro.plate("data", x.shape[0], use_cuda=self.use_cuda, device=self.device):
+        with pyro.plate("data", x.shape[0], device=self.device):
             # Sample z from prior.
             z = pyro.sample(
                 "z", dist.Normal(loc=self.z_loc_prior, scale=self.z_scale_prior).expand_by([x.size(0)]).to_event(1)
@@ -518,7 +513,7 @@ class RemoveBackgroundPyroModel(nn.Module):
         pyro.sample("phi", dist.Gamma(phi_conc, phi_rate))
 
         # Happens in parallel for each data point (cell barcode) independently:
-        with pyro.plate("data", x.shape[0], use_cuda=self.use_cuda, device=self.device):
+        with pyro.plate("data", x.shape[0], device=self.device):
             # Sample swapping fraction rho.
             if self.include_rho:
                 _rho = pyro.sample("rho", dist.Beta(rho_alpha, rho_beta).expand_by([x.size(0)]))

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -36,6 +36,7 @@ from cellbender.remove_background.sparse_utils import (
     csr_set_rows_to_zero,
     dense_to_sparse_op_torch,
     log_prob_sparse_to_dense,
+    tensor_to_device,
 )
 
 logger = logging.getLogger("cellbender")
@@ -1122,9 +1123,9 @@ class PRq(PosteriorRegularization):
 
         for i in range(n_chunks):
             # B index here represents a batch: the re-defined m-index
-            log_pdf_noise_counts_BC = torch.tensor(
-                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)])
-            ).to(device)
+            log_pdf_noise_counts_BC = tensor_to_device(
+                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)]), device
+            )
             noise_count_BC = (
                 torch.arange(log_pdf_noise_counts_BC.shape[1])
                 .to(log_pdf_noise_counts_BC.device)
@@ -1216,7 +1217,7 @@ class PRq(PosteriorRegularization):
             noise_count_posterior_coo=noise_count_posterior_coo,
             alpha=alpha,
         )
-        log_target_M = torch.tensor(list(log_target_dict.values())).to(device)
+        log_target_M = tensor_to_device(list(log_target_dict.values()), device)
 
         reg_noise_count_posterior_coo = PRq._chunked_compute_regularized_posterior(
             noise_count_posterior_coo=noise_count_posterior_coo,
@@ -1290,7 +1291,7 @@ class PRmu(PosteriorRegularization):
             else:
                 noise_counts = map_noise_csr.sum()
 
-            return torch.tensor(noise_counts).to(device)
+            return tensor_to_device(noise_counts, device)
 
         # Perform binary search for beta.
         per_gene = False
@@ -1346,9 +1347,9 @@ class PRmu(PosteriorRegularization):
 
         for i in range(n_chunks):
             # B index here represents a batch: the re-defined m-index
-            log_pdf_noise_counts_BC = torch.tensor(
-                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)])
-            ).to(device)
+            log_pdf_noise_counts_BC = tensor_to_device(
+                log_prob_sparse_to_dense(densifiable_csr[(i * chunk_size) : ((i + 1) * chunk_size)]), device
+            )
             noise_count_BC = (
                 torch.arange(log_pdf_noise_counts_BC.shape[1])
                 .to(log_pdf_noise_counts_BC.device)
@@ -1651,7 +1652,7 @@ def compute_mean_target_removal_as_function(
             target = target + fpr * approx_signal_csr.sum()
 
         # Return target scaled to be per-cell.
-        return torch.tensor(target / n_cells).to(device)
+        return tensor_to_device(target / n_cells, device)
 
     return _target_fun
 

--- a/cellbender/remove_background/posterior.py
+++ b/cellbender/remove_background/posterior.py
@@ -20,7 +20,7 @@ import scipy.sparse as sp
 import torch
 
 import cellbender.remove_background.consts as consts
-from cellbender.monitor import get_hardware_usage
+from cellbender.monitor import empty_cache, get_hardware_usage
 from cellbender.remove_background.checkpoint import load_checkpoint, load_from_checkpoint, make_tarball, unpack_tarball
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.data.dataset import get_dataset_obj
@@ -81,7 +81,7 @@ def load_or_compute_posterior_and_save(
                 posterior.regularize_posterior(
                     regularization=PRq,
                     alpha=args.prq_alpha,
-                    device="cuda",
+                    device=posterior.device,
                 )
             elif args.posterior_regularization == "PRmu":
                 assert dataset_obj.data is not None
@@ -90,7 +90,7 @@ def load_or_compute_posterior_and_save(
                     raw_count_matrix=dataset_obj.data["matrix"],
                     fpr=args.fpr[0],
                     per_gene=False,
-                    device="cuda",
+                    device=posterior.device,
                 )
             elif args.posterior_regularization == "PRmu_gene":
                 assert dataset_obj.data is not None
@@ -99,7 +99,7 @@ def load_or_compute_posterior_and_save(
                     raw_count_matrix=dataset_obj.data["matrix"],
                     fpr=args.fpr[0],
                     per_gene=True,
-                    device="cuda",
+                    device=posterior.device,
                 )
             else:
                 raise ValueError(
@@ -212,8 +212,14 @@ class Posterior:
             encoder["z"].eval()
             encoder["other"].eval()
             vi_model.decoder.eval()
-        self.use_cuda = torch.cuda.is_available() if vi_model is None else vi_model.use_cuda
-        self.device = "cuda" if self.use_cuda else "cpu"
+        if vi_model is not None:
+            self.device = vi_model.device
+        elif torch.cuda.is_available():
+            self.device = "cuda"
+        elif torch.backends.mps.is_available():
+            self.device = "mps"
+        else:
+            self.device = "cpu"
         self.analyzed_gene_inds = None if (dataset_obj is None) else dataset_obj.analyzed_gene_inds
         if dataset_obj is not None and dataset_obj.data is not None:
             self.count_matrix_shape: tuple | None = dataset_obj.data["matrix"].shape
@@ -455,7 +461,7 @@ class Posterior:
 
         assert self.dataset_obj is not None
         # Compute posterior in mini-batches.
-        torch.cuda.empty_cache()
+        empty_cache(self.device)
 
         # Dataloader for cells only.
         analyzed_bcs_only = True
@@ -485,7 +491,7 @@ class Posterior:
             batch_size=self.posterior_batch_size,
             fraction_empties=0.0,
             shuffle=False,
-            use_cuda=self.use_cuda,
+            device=self.device,
         )
 
         bcs = []  # barcode index
@@ -515,7 +521,7 @@ class Posterior:
 
             if self.debug:
                 logger.debug(f"Posterior minibatch starting with droplet {ind}")
-                logger.debug("\n" + get_hardware_usage(use_cuda=self.use_cuda))
+                logger.debug("\n" + get_hardware_usage(device=self.device))
 
             # Compute noise count probabilities.
             noise_log_pdf_NGC, noise_count_offset_NG = self.noise_log_pdf(
@@ -869,7 +875,7 @@ class Posterior:
             return None
 
         data_loader = self.dataset_obj.get_dataloader(
-            use_cuda=self.use_cuda, analyzed_bcs_only=True, batch_size=500, shuffle=False
+            device=self.device, analyzed_bcs_only=True, batch_size=500, shuffle=False
         )
 
         n_analyzed = data_loader.dataset.shape[0]

--- a/cellbender/remove_background/run.py
+++ b/cellbender/remove_background/run.py
@@ -102,7 +102,7 @@ def run_remove_background(args: argparse.Namespace) -> Posterior:
     logger.info("Running remove-background")
 
     # Run pytorch multithreaded if running on CPU: but this makes little difference in runtime.
-    if not args.use_cuda:
+    if args.device == "cpu":
         if args.n_threads is not None:
             n_jobs = args.n_threads
         else:
@@ -274,7 +274,7 @@ def compute_output_denoised_counts_reports_metrics(
             index_converter=posterior.index_converter,
             raw_count_csr_for_cells=cell_counts,
             n_cells=len(cell_inds),
-            device="cuda" if args.use_cuda else "cpu",  # TODO check this
+            device=args.device,  # TODO check this
             per_gene=True,
         )
 
@@ -296,7 +296,7 @@ def compute_output_denoised_counts_reports_metrics(
                 raw_count_matrix=posterior.dataset_obj.data["matrix"],
                 fpr=fpr,
                 per_gene=True if (args.posterior_regularization == "PRmu_gene") else False,
-                device="cuda",
+                device=posterior.device,
             )
         else:
             # Other posterior regularizations were already performed in
@@ -318,7 +318,7 @@ def compute_output_denoised_counts_reports_metrics(
             noise_targets_per_gene=noise_targets,
             q=args.cdf_threshold_q,
             alpha=args.prq_alpha,
-            device="cuda" if args.use_cuda else "cpu",
+            device=args.device,
             use_multiple_processes=args.use_multiprocessing_estimation,
         )
 
@@ -662,14 +662,14 @@ def run_inference(
     # Set random seed, updating global state of python, numpy, and torch RNGs.
     pyro.clear_param_store()
     pyro.set_rng_seed(consts.RANDOM_SEED)
-    if args.use_cuda:
+    if args.device == "cuda":
         torch.cuda.manual_seed_all(consts.RANDOM_SEED)
 
     # Attempt to load from a previously-saved checkpoint.
     ckpt = attempt_load_checkpoint(
         filebase=checkpoint_filename,
         tarball_name=args.input_checkpoint_tarball,
-        force_device="cuda:0" if args.use_cuda else "cpu",
+        force_device="cuda:0" if args.device == "cuda" else args.device,
         force_use_checkpoint=args.force_use_checkpoint,
     )
     ckpt_loaded = ckpt["loaded"]  # True if a checkpoint was loaded successfully
@@ -739,7 +739,7 @@ def run_inference(
             analyzed_gene_names=dataset_obj.data["gene_names"][dataset_obj.analyzed_gene_inds],
             empty_UMI_threshold=dataset_obj.empty_UMI_threshold,
             log_counts_crossover=dataset_obj.priors["log_counts_crossover"],
-            use_cuda=args.use_cuda,
+            device=args.device,
         )
 
         # Load the dataset into DataLoaders.
@@ -754,7 +754,7 @@ def run_inference(
             training_fraction=frac,
             fraction_empties=args.fraction_empties,
             shuffle=True,
-            use_cuda=args.use_cuda,
+            device=args.device,
         )
 
         # Set up optimizer (optionally wrapped in a learning rate scheduler).

--- a/cellbender/remove_background/sparse_utils.py
+++ b/cellbender/remove_background/sparse_utils.py
@@ -33,6 +33,19 @@ def dense_to_sparse_op_torch(
     return nonzero_inds_tuple + (nonzero_values,)
 
 
+def tensor_to_device(data, device: str) -> torch.Tensor:
+    """Put data on a device, downcasting float64 for backends that lack it.
+
+    The MPS backend has no float64, and the densify helpers below go through
+    numpy, which produces float64. Log probabilities are the only thing that
+    travels this path, and they are consumed in float32 on the GPU anyway.
+    """
+    tensor = torch.as_tensor(data)
+    if tensor.dtype == torch.float64 and device.startswith("mps"):
+        tensor = tensor.float()
+    return tensor.to(device)
+
+
 def log_prob_sparse_to_dense(coo: sp.coo_matrix) -> np.ndarray:
     """Densify a sparse log prob COO data structure. Same as coo_matrix.todense()
     except it fills missing entries with -np.inf instead of 0, since 0 is a

--- a/cellbender/remove_background/train.py
+++ b/cellbender/remove_background/train.py
@@ -9,12 +9,11 @@ from typing import List, Tuple
 
 import numpy as np
 import pyro
-import torch
 from pyro.infer import SVI
 from pyro.util import ignore_jit_warnings
 
 import cellbender.remove_background.consts as consts
-from cellbender.monitor import get_hardware_usage
+from cellbender.monitor import empty_cache, get_hardware_usage
 from cellbender.remove_background.checkpoint import save_checkpoint
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.exceptions import ElboException, NanException
@@ -161,7 +160,7 @@ def run_training(
             if args.debug:
                 # Don't spend time pinging usage stats if we will not use the log.
                 # TODO: use multiprocessing to sample these stats DURING training...
-                logger.debug("\n" + get_hardware_usage(use_cuda=model.use_cuda))
+                logger.debug("\n" + get_hardware_usage(device=model.device))
 
             # Display duration of an epoch (use 2 to avoid initializations).
             if epoch == start_epoch + 1:
@@ -295,6 +294,6 @@ def run_training(
             )
 
     # Free up all the GPU memory we can once training is complete.
-    torch.cuda.empty_cache()
+    empty_cache(model.device)
 
     return train_elbo, model.loss["test"]["elbo"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from cellbender.remove_background.data.extras.simulate import generate_sample_di
 from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
 
 USE_CUDA = torch.cuda.is_available()
+USE_MPS = torch.backends.mps.is_available()
 
 
 def sparse_matrix_equal(mat1, mat2):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,13 @@ from cellbender.remove_background.data.io import write_matrix_to_cellranger_h5
 USE_CUDA = torch.cuda.is_available()
 USE_MPS = torch.backends.mps.is_available()
 
+# Every device-dependent test runs on each backend that this machine has.
+DEVICE_PARAMS = [
+    "cpu",
+    pytest.param("cuda", marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA")),
+    pytest.param("mps", marks=pytest.mark.skipif(not USE_MPS, reason="requires MPS")),
+]
+
 
 def sparse_matrix_equal(mat1, mat2):
     """Fast assertion that sparse matrices are equal"""

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -186,10 +186,10 @@ class PyroModel(torch.nn.Module):
         self.encoder = EncodeZ(input_dim=dim, hidden_dims=[hidden_layer], output_dim=z_dim)
         self.decoder = Decoder(input_dim=z_dim, hidden_dims=[hidden_layer], output_dim=dim)
         self.z_dim = z_dim
-        self.use_cuda = torch.cuda.is_available()
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.normal = pyro.distributions.Normal
         self.loss = []
-        # self.to(device='cuda' if self.use_cuda else 'cpu')  # CUDA not tested
+        # self.to(device=self.device)  # accelerators not tested here
 
     def model(self, x: torch.FloatTensor):
         pyro.module("decoder", self.decoder, update_module_params=True)
@@ -392,7 +392,7 @@ def test_save_and_load_cellbender_checkpoint(tmpdir_factory, cuda, scheduler):
     args.z_dim = 10
     args.z_hidden_dims = [50]
     args.model = "ambient"
-    args.use_cuda = cuda
+    args.device = "cuda" if cuda else "cpu"
     args.use_jit = False
     args.learning_rate = 1e-3
     args.training_fraction = 0.9

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -11,7 +11,7 @@ import pyro
 import pyro.optim as optim
 import pytest
 import torch
-from conftest import USE_CUDA
+from conftest import DEVICE_PARAMS, USE_CUDA
 from torch.distributions import constraints
 
 import cellbender
@@ -34,19 +34,19 @@ from cellbender.remove_background.vae.encoder import EncodeZ
 
 
 class RandomState:
-    def __init__(self, use_cuda=False):
+    def __init__(self, device="cpu"):
         self.python = random.randint(0, 100000)
         self.numpy = np.random.randint(0, 100000, size=1).item()
         self.torch = torch.randint(low=0, high=100000, size=[1], device="cpu").item()
-        self.use_cuda = use_cuda
-        if self.use_cuda:
-            self.cuda = torch.randint(low=0, high=100000, size=[1], device="cuda").item()
+        self.device = device
+        if self.device != "cpu":
+            self.accelerator = torch.randint(low=0, high=100000, size=[1], device=self.device).item()
 
     def __repr__(self):
-        if self.use_cuda:
-            return f"python {self.python}; numpy {self.numpy}; torch {self.torch}; torch_cuda {self.cuda}"
-        else:
-            return f"python {self.python}; numpy {self.numpy}; torch {self.torch}"
+        base = f"python {self.python}; numpy {self.numpy}; torch {self.torch}"
+        if self.device != "cpu":
+            return f"{base}; torch_{self.device} {self.accelerator}"
+        return base
 
 
 def test_create_workflow_hashcode():
@@ -148,12 +148,8 @@ def test_that_randomstate_plus_perturb_gives_perturbedrandomstate(perturbed_rand
     assert str(prs0) == str(this_prs0)
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_save_and_load_random_state(tmpdir_factory, perturbed_random_state_dict, cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_save_and_load_random_state(tmpdir_factory, perturbed_random_state_dict, device):
     """Test whether random states are being preserved correctly.
     perturbed_random_state_dict is important since it initializes the state."""
 
@@ -162,12 +158,12 @@ def test_save_and_load_random_state(tmpdir_factory, perturbed_random_state_dict,
     save_random_state(filebase=filebase)
 
     # see "what would have happened had we continued"
-    counterfactual = RandomState(use_cuda=cuda)
-    incorrect = RandomState(use_cuda=cuda)  # a second draw
+    counterfactual = RandomState(device=device)
+    incorrect = RandomState(device=device)  # a second draw
 
     # load the random states and check random number generators
     load_random_state(filebase=filebase)
-    actual = RandomState(use_cuda=cuda)
+    actual = RandomState(device=device)
 
     # check equality
     assert str(counterfactual) == str(actual)
@@ -350,13 +346,9 @@ def test_save_and_load_pyro_checkpoint(tmpdir_factory, batch_size_n):
             assert disagreement == 0, "Guide traces disagree with and without checkpoint restart"
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
 @pytest.mark.parametrize("scheduler", [False, True], ids=lambda b: "OneCycleLR" if b else "Adam")
-def test_save_and_load_cellbender_checkpoint(tmpdir_factory, cuda, scheduler):
+def test_save_and_load_cellbender_checkpoint(tmpdir_factory, device, scheduler):
     """Check and see if restarting from a checkpoint picks up in the same place
     we left off.  Use our model and dataloader.
     """
@@ -392,7 +384,7 @@ def test_save_and_load_cellbender_checkpoint(tmpdir_factory, cuda, scheduler):
     args.z_dim = 10
     args.z_hidden_dims = [50]
     args.model = "ambient"
-    args.device = "cuda" if cuda else "cpu"
+    args.device = device
     args.use_jit = False
     args.learning_rate = 1e-3
     args.training_fraction = 0.9

--- a/tests/test_dataprep.py
+++ b/tests/test_dataprep.py
@@ -27,7 +27,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
         batch_size=5,
         fraction_empties=0.0,
         shuffle=False,
-        use_cuda=cuda,
+        device="cuda" if cuda else "cpu",
     )
     sorted_data_loader = DataLoader(
         d["matrix"],
@@ -36,7 +36,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
         fraction_empties=0.0,
         shuffle=False,
         sort_by=lambda x: -1 * np.array(x.max(axis=1).todense()).squeeze(),
-        use_cuda=cuda,
+        device="cuda" if cuda else "cpu",
     )
 
     # try to shuffle and sort at the same time, and expect a failure
@@ -48,7 +48,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
             fraction_empties=0.0,
             shuffle=True,
             sort_by=lambda x: -1 * np.array(x.max(axis=1).todense()).squeeze(),
-            use_cuda=cuda,
+            device="cuda" if cuda else "cpu",
         )
 
     # this is copied from infer.BasePosterior._get_mean() which is not ideal

--- a/tests/test_dataprep.py
+++ b/tests/test_dataprep.py
@@ -3,21 +3,14 @@
 import numpy as np
 import pytest
 import scipy.sparse as sp
-import torch
-from conftest import sparse_matrix_equal
+from conftest import DEVICE_PARAMS, sparse_matrix_equal
 
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.sparse_utils import dense_to_sparse_op_torch
 
-USE_CUDA = torch.cuda.is_available()
 
-
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_dataloader_sorting(simulated_dataset, cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_dataloader_sorting(simulated_dataset, device):
     """test dataset.py _overwrite_matrix_with_columns_from_another()"""
 
     d = simulated_dataset
@@ -27,7 +20,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
         batch_size=5,
         fraction_empties=0.0,
         shuffle=False,
-        device="cuda" if cuda else "cpu",
+        device=device,
     )
     sorted_data_loader = DataLoader(
         d["matrix"],
@@ -36,7 +29,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
         fraction_empties=0.0,
         shuffle=False,
         sort_by=lambda x: -1 * np.array(x.max(axis=1).todense()).squeeze(),
-        device="cuda" if cuda else "cpu",
+        device=device,
     )
 
     # try to shuffle and sort at the same time, and expect a failure
@@ -48,7 +41,7 @@ def test_dataloader_sorting(simulated_dataset, cuda):
             fraction_empties=0.0,
             shuffle=True,
             sort_by=lambda x: -1 * np.array(x.max(axis=1).todense()).squeeze(),
-            device="cuda" if cuda else "cpu",
+            device=device,
         )
 
     # this is copied from infer.BasePosterior._get_mean() which is not ideal

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 import pytest
-from conftest import USE_CUDA
+from conftest import USE_CUDA, USE_MPS
 
 from cellbender.base_cli import get_populated_argparser
 from cellbender.remove_background import consts
@@ -13,11 +13,14 @@ from cellbender.remove_background.downstream import anndata_from_h5
 
 
 @pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
+    "device",
+    [
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA")),
+        pytest.param("mps", marks=pytest.mark.skipif(not USE_MPS, reason="requires MPS")),
+    ],
 )
-def test_full_run(tmpdir_factory, h5_v3_file, cuda):
+def test_full_run(tmpdir_factory, h5_v3_file, device):
     """Do a full run of the command line tool using a small simulated dataset"""
 
     tmp_dir = tmpdir_factory.mktemp("data")
@@ -36,8 +39,8 @@ def test_full_run(tmpdir_factory, h5_v3_file, cuda):
         "--epochs",
         "5",
     ]
-    if cuda:
-        input_args.append("--cuda")
+    if device != "cpu":
+        input_args.append(f"--{device}")
     args = get_populated_argparser().parse_args(input_args[1:])
     args = CLI.validate_args(args=args)
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -18,4 +18,4 @@ def test_get_hardware_usage(cuda):
     we left off.  Use our model and dataloader.
     """
 
-    print(get_hardware_usage(use_cuda=cuda))
+    print(get_hardware_usage(device="cuda" if cuda else "cpu"))

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,21 +1,15 @@
 """Tests for monitoring function."""
 
 import pytest
-import torch
+from conftest import DEVICE_PARAMS
 
 from cellbender.monitor import get_hardware_usage
 
-USE_CUDA = torch.cuda.is_available()
 
-
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_get_hardware_usage(cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_get_hardware_usage(device):
     """Check and see if restarting from a checkpoint picks up in the same place
     we left off.  Use our model and dataloader.
     """
 
-    print(get_hardware_usage(device="cuda" if cuda else "cpu"))
+    print(get_hardware_usage(device=device))

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 import torch
-from conftest import sparse_matrix_equal
+from conftest import DEVICE_PARAMS, sparse_matrix_equal
 
 from cellbender.remove_background.estimation import Mean
 from cellbender.remove_background.posterior import (
@@ -19,9 +19,6 @@ from cellbender.remove_background.posterior import (
     torch_binary_search,
 )
 from cellbender.remove_background.sparse_utils import dense_to_sparse_op_torch, log_prob_sparse_to_dense
-
-USE_CUDA = torch.cuda.is_available()
-
 
 # NOTE: issues caught
 # - have a test that actually creates a posterior
@@ -70,12 +67,8 @@ def log_prob_coo(request, log_prob_coo_base) -> Dict[str, Union[sp.coo_matrix, n
 
 @pytest.mark.parametrize("alpha", [0, 1, 2], ids=lambda a: f"alpha{a}")
 @pytest.mark.parametrize("n_chunks", [1, 2], ids=lambda n: f"{n}chunks")
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_PRq(log_prob_coo, alpha, n_chunks, cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_PRq(log_prob_coo, alpha, n_chunks, device):
 
     target_tolerance = 0.001
 
@@ -118,7 +111,7 @@ def test_PRq(log_prob_coo, alpha, n_chunks, cuda):
         noise_count_posterior_coo=log_prob_coo["coo"],
         noise_offsets=log_prob_coo["offsets"],
         alpha=alpha,
-        device="cuda" if cuda else "cpu",
+        device=device,
         target_tolerance=target_tolerance,
         n_chunks=n_chunks,
     )
@@ -141,12 +134,8 @@ def test_PRq(log_prob_coo, alpha, n_chunks, cuda):
 @pytest.mark.parametrize("n_chunks", [1, 2], ids=lambda n: f"{n}chunks")
 # @pytest.mark.parametrize('per_gene', [False, True], ids=lambda n: 'per_gene' if n else 'overall')
 @pytest.mark.parametrize("per_gene", [False], ids=lambda n: "per_gene" if n else "overall")
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, device):
 
     target_tolerance = 0.5
 
@@ -168,7 +157,7 @@ def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
     mean_noise_csr = estimator.estimate_noise(
         noise_log_prob_coo=log_prob_coo["coo"],
         noise_offsets=log_prob_coo["offsets"],
-        device="cuda" if cuda else "cpu",
+        device=device,
     )
     print(f"Mean estimator removes {mean_noise_csr.sum()} counts total")
 
@@ -180,7 +169,7 @@ def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
         raw_count_csr_for_cells=count_matrix,
         n_cells=n_cells,
         index_converter=index_converter,
-        device="cuda" if cuda else "cpu",
+        device=device,
         per_gene=per_gene,
     )
     targets = target_fun(fpr)
@@ -195,7 +184,7 @@ def test_PRmu(log_prob_coo, fpr, per_gene, n_chunks, cuda):
         raw_count_matrix=count_matrix,
         fpr=fpr,
         per_gene=per_gene,
-        device="cuda" if cuda else "cpu",
+        device=device,
         target_tolerance=target_tolerance,
         n_chunks=n_chunks,
     )
@@ -316,17 +305,13 @@ def test_torch_binary_search():
 
 @pytest.mark.parametrize("fpr", [0.0, 0.1, 0.5, 0.75, 1], ids=lambda a: f"fpr{a}")
 @pytest.mark.parametrize("per_gene", [False], ids=lambda n: "per_gene" if n else "overall")
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_compute_mean_target_removal_as_function(log_prob_coo, fpr, per_gene, cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_compute_mean_target_removal_as_function(log_prob_coo, fpr, per_gene, device):
     """The target removal computation, very important for the MCKP output"""
 
     noise_count_posterior_coo = log_prob_coo["coo"]
     noise_offsets = log_prob_coo["offsets"]
-    device = "cuda" if cuda else "cpu"
+    device = device
 
     print("log prob posterior coo")
     print(noise_count_posterior_coo)

--- a/tests/test_sparse_utils.py
+++ b/tests/test_sparse_utils.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 import scipy.sparse as sp
-import torch
-from conftest import sparse_matrix_equal
+from conftest import DEVICE_PARAMS, sparse_matrix_equal
 
 from cellbender.remove_background.data.dataprep import DataLoader
 from cellbender.remove_background.sparse_utils import (
@@ -12,8 +11,6 @@ from cellbender.remove_background.sparse_utils import (
     overwrite_matrix_with_columns_from_another,
     todense_fill,
 )
-
-USE_CUDA = torch.cuda.is_available()
 
 
 @pytest.mark.parametrize("val", [0, 1, np.nan, np.inf, -np.inf])
@@ -39,12 +36,8 @@ def test_todense_fill(val):
     np.testing.assert_array_equal(brute_force, dense)
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
-def test_dense_to_sparse_op_torch(simulated_dataset, cuda):
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
+def test_dense_to_sparse_op_torch(simulated_dataset, device):
     """test infer.py BasePosterior.dense_to_sparse_op_torch()"""
 
     d = simulated_dataset
@@ -54,7 +47,7 @@ def test_dense_to_sparse_op_torch(simulated_dataset, cuda):
         batch_size=5,
         fraction_empties=0.0,
         shuffle=False,
-        device="cuda" if cuda else "cpu",
+        device=device,
     )
 
     barcodes = []

--- a/tests/test_sparse_utils.py
+++ b/tests/test_sparse_utils.py
@@ -54,7 +54,7 @@ def test_dense_to_sparse_op_torch(simulated_dataset, cuda):
         batch_size=5,
         fraction_empties=0.0,
         shuffle=False,
-        use_cuda=cuda,
+        device="cuda" if cuda else "cpu",
     )
 
     barcodes = []

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -47,7 +47,7 @@ def test_one_cycle_scheduler(dropped_minibatch, cuda):
         training_fraction=1.0,
         fraction_empties=0.3,
         shuffle=True,
-        use_cuda=cuda,
+        device="cuda" if cuda else "cpu",
     )
 
     print(f"epochs = {epochs}")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -5,7 +5,7 @@ import pyro.infer.trace_elbo
 import pytest
 import scipy.sparse as sp
 import torch
-from conftest import USE_CUDA
+from conftest import DEVICE_PARAMS
 from pyro.infer.svi import SVI
 
 from cellbender.remove_background.data.dataprep import prep_sparse_data_for_training as prep_data_for_training
@@ -13,19 +13,15 @@ from cellbender.remove_background.run import get_optimizer
 from cellbender.remove_background.train import train_epoch
 
 
-@pytest.mark.parametrize(
-    "cuda",
-    [False, pytest.param(True, marks=pytest.mark.skipif(not USE_CUDA, reason="requires CUDA"))],
-    ids=lambda b: "cuda" if b else "cpu",
-)
+@pytest.mark.parametrize("device", DEVICE_PARAMS)
 @pytest.mark.parametrize("dropped_minibatch", [False, True], ids=["", "dropped_minibatch"])
-def test_one_cycle_scheduler(dropped_minibatch, cuda):
+def test_one_cycle_scheduler(dropped_minibatch, device):
 
     # if there is a minibatch so small that it's below consts.SMALLEST_ALLOWED_BATCH
     # then the minibatch gets skipped. make sure this works with the scheduler.
 
     pyro.clear_param_store()
-    device = "cuda" if cuda else "cpu"
+    device = device
 
     n_cells = 3580
     n_empties = 50000
@@ -47,7 +43,7 @@ def test_one_cycle_scheduler(dropped_minibatch, cuda):
         training_fraction=1.0,
         fraction_empties=0.3,
         shuffle=True,
-        device="cuda" if cuda else "cpu",
+        device=device,
     )
 
     print(f"epochs = {epochs}")


### PR DESCRIPTION
Closes #149, closes #171.

I have an Apple silicon Mac and would like to run CellBender on its GPU, so I
picked this up. The description below was prepared with an AI assistant, so it
is quoted rather than presented as my own prose; I checked the operator
availability claims and ran the test suite myself.

> ## Why now
>
> @sjfleming already wrote this feature in September 2022, on the
> `sf_pytorch_mps_backend` branch (8a70ea3, "Add --mps argument and use more
> general device arg"). It was never merged because at the time the model hit
>
> ```
> NotImplementedError: The operator 'aten::_standard_gamma' is not currently
> implemented for the MPS device.
> ```
>
> which is what @asabjorklund reported on #149 in October 2022, and which is why
> the answer on #171 in January 2023 was "we will have to wait for a lot more of
> the PyTorch work to be completed".
>
> That wait is over for this model. `_standard_gamma` now has an MPS kernel, and
> so does every other sampler CellBender draws from:
>
> | distribution | MPS kernel in current PyTorch |
> |---|---|
> | `Gamma` | `_s_gamma_mps` |
> | `Dirichlet` | `_s_dirichlet_mps` |
> | `Poisson` | `_s_poisson_mps` |
> | `NegativeBinomial` | `_s_binomial_mps`, `multinomial` |
> | `Beta`, `LogNormal`, `Categorical` | composite over the above |
>
> The tensor operators the model uses (`logsumexp`, `logaddexp`,
> `linalg.vector_norm`, `matmul`, `where`, `clamp`, `cat`, `isnan`, `isinf`,
> `randperm`, `argmax`, `nonzero`, `Softplus`, `BatchNorm`, `Linear`, `Dropout`)
> all have MPS dispatch as well.
>
> float64 was the one thing that did still need work, and it did not show up in
> a grep: `sparse_utils.todense_fill` densifies through numpy, which yields
> float64, and the mean estimator built its coefficient vector with
> `torch.arange(..., dtype=float)`. Both are fine on CPU and CUDA and both raise
> on MPS. The second commit fixes them without changing behaviour on any other
> backend.
>
> ## What this does
>
> It ports the `sf_pytorch_mps_backend` design onto the current tree. The layout
> has moved since 2022: `argparse.py` is now `argparser.py`, `infer.py` is now
> `posterior.py`, and `run.py`, `monitor.py` and `checkpoint.py` did not exist.
>
> - `--mps` flag, alongside `--cuda`. CUDA wins if both are given.
> - The `use_cuda` boolean threaded through the model, the dataloaders and the
>   posterior becomes an explicit `device` string. `--cuda` keeps its behaviour
>   and its argparse destination, so nothing changes for existing users.
> - `pyro.plate` no longer gets `use_cuda`; `device` alone is what it needs.
> - `torch.cuda.empty_cache()`, previously called unconditionally, becomes
>   `empty_cache(device)`, which also frees the MPS cache. This matters more on
>   unified memory than it does on a discrete card.
> - `get_hardware_usage` takes a device string and reports MPS allocated memory
>   rather than shelling out to `nvidia-smi`.
> - The MPS availability check distinguishes a PyTorch build without MPS from a
>   machine without an MPS-capable device, and the "a GPU is available but will
>   not be used" warning now fires for Apple silicon too.
>
> ## Testing
>
> ```
> make lint       # ruff check, ruff format --check
> make typecheck  # mypy
> make test       # pytest
> ```
>
> Lint and typecheck are clean. 107 tests pass, 20 skip. One failure,
> `test_integration.py::test_full_run[cpu]`, is an environment problem and not a
> code one: nbconvert cannot import `notebook.services` in my environment, so
> the HTML report is never written and the assertion on its existence fails. The
> CellBender run inside that same test completes, and its assertions on the
> barcodes and on the count matrix pass.

## Testing on Apple silicon

I have an M-series Mac, so all of the below was run on the hardware.

### Test suite

The device-dependent tests were parametrized over a `cuda` boolean, so on a
machine without CUDA they only ever ran on CPU. They now use a shared
`DEVICE_PARAMS` list covering whichever backends the machine actually has, so
**51 tests execute on MPS**, up from one: checkpoint save and restore, the
random-state round trip, the posterior regularizations (PRq, PRmu, per-gene and
not), the sparse ops, the dataloader, and the full end-to-end run.

```
make lint       # clean
make typecheck  # clean
make test       # 225 passed, 70 skipped, 0 failed
```

The 70 skips are the CUDA variants, which cannot run here.

Extending that coverage is what caught the third commit: `save_random_state` and
`load_random_state` handled the CUDA generator but not the MPS one, so a run
resumed from a checkpoint on Apple silicon would have silently continued with a
different random stream.

### Real data, full run

`500_PBMC_3p_LT_Chromium_X` raw feature matrix from 10x, 13555 barcodes and
36601 genes, default settings, so 150 epochs. Completes on MPS, writes every
output (`out.h5`, `out_filtered.h5`, metrics, cell barcodes, PDF, posterior,
checkpoint, HTML report). `--estimator-multiple-cpu` also works on MPS: MCKP
estimation took 14.3 s in parallel against 64.9 s single process.

Same input on both backends, run sequentially with nothing else on the machine,
8 threads:

```
MPS   256 s
CPU  1335 s     5.2x
```

Output agreement, 1163 analyzed droplets:

```
cell calls            cpu 573   mps 574     99.91 % agreement
median |diff p|       2.0e-05
total denoised counts 6353908 vs 6352939    relative 1.5e-04
negative entries      cpu 0     mps 0
```

One droplet is called differently, at p=0.04 on CPU against p=0.94 on MPS. That
looked like something to flag until I ran the control, which is worth reporting
in full:

```
MPS 4 threads vs MPS 8 threads   max |diff p| 0.00e+00   0 divergent calls   counts identical
CPU 4 threads vs CPU 8 threads   max |diff p| 9.48e-01   2 divergent calls   counts 4.3e-04
MPS vs CPU                       max |diff p| 9.51e-01   1 divergent call    counts 1.5e-04
```

Changing the CPU thread count moves *two* cell calls, which is more than the gap
between the backends. The two MPS runs are bit-identical to each other. So the
single divergent droplet sits inside CellBender's own run-to-run variation on
CPU rather than being an MPS artifact, and MPS is the more reproducible of the
two here.

### Still untested

Only one real dataset, and a small one. I have not tried a large sample, an
Antibody Capture or CRISPR feature set on real data, or `--cuda` (no NVIDIA
hardware here), though the CUDA paths are unchanged except for the `use_cuda` to
`device` rename.

Leaving this as a draft until you have had a look at the approach, since it
touches the device plumbing throughout. Happy to run anything else you want
checked on the hardware, and to split the three commits into separate PRs if you
would rather review them apart.

For the record on #149: @BradBalderson reported a fork running a few epochs on an
M3 and then failing with a tensor shape mismatch absent on CPU. That fork relied
on `PYTORCH_ENABLE_MPS_FALLBACK=1`, which this PR does not need. 150 epochs on
real data here showed nothing of the sort.

cc @sjfleming @alecw
